### PR TITLE
Rename artifact to `asana` and maven deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,16 @@ You can also use the raw API to fetch a page at a time:
             break;
         }
     }
+
+# Deployment
+
+To deploy a new version to the Maven Central Repository, you can run:
+
+`mvn deploy -P release --settings settings.xml`
+
+Before you do this, you must set a few environment variables to authenticate:
+
+* Maven credentials: `MAVEN_USERNAME` and `MAVEN_PASSWORD`
+* GPG keyname and password: `MAVEN_GPG_KEYNAME` and `MAVEN_GPG_PASSWORD`
+
+You then can [log in](https://oss.sonatype.org/) to close and deploy the release.

--- a/pom.xml
+++ b/pom.xml
@@ -2,11 +2,24 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.asana</groupId>
-    <artifactId>java-asana</artifactId>
+    <artifactId>asana</artifactId>
     <packaging>jar</packaging>
-    <version>0.1-SNAPSHOT</version>
-    <name>java-asana</name>
+    <version>0.1</version>
+    <name>asana</name>
+    <description>A Java client for the Asana API.</description>
     <url>http://maven.apache.org</url>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+
 
     <issueManagement>
         <url>https://github.com/Asana/java-asana/issues</url>
@@ -87,22 +100,22 @@
                 </configuration>
             </plugin>
 
-          <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-jar-plugin</artifactId>
-              <version>2.6</version>
-              <configuration>
-                  <archive>
-                      <manifest>
-                          <mainClass>com.asana.examples.ExampleScript</mainClass>
-                          <addClasspath>true</addClasspath>
-                          <classpathPrefix>lib/</classpathPrefix>
-                          <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                          <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-                      </manifest>
-                  </archive>
-              </configuration>
-          </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.6</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.asana.examples.ExampleScript</mainClass>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>lib/</classpathPrefix>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
 
 <!-- The below plugins are useful when debugging locally to be able to run an
 example, bringing in the proper CLASSPATHs of all dependencies, from the actual
@@ -144,7 +157,7 @@ final JAR file instead of the intermediate .class files. -->
                           <executable>java</executable>
                           <arguments>
                               <argument>-jar</argument>
-                              <argument>${basedir}/target/java-asana-${project.version}.jar</argument>
+                              <argument>${basedir}/target/asana-${project.version}.jar</argument>
                               <argument>com.asana.examples.ExampleScript</argument>
                           </arguments>
                       </configuration>
@@ -154,5 +167,57 @@ final JAR file instead of the intermediate .class files. -->
 -->
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.5</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>2.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>2.9.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,22 @@
+<settings>
+    <servers>
+        <server>
+            <id>ossrh</id>
+            <username>${env.MAVEN_USERNAME}</username>
+            <password>${env.MAVEN_PASSWORD}</password>
+        </server>
+    </servers>
+    <profiles>
+        <profile>
+            <id>ossrh</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <gpg.keyname>${env.MAVEN_GPG_KEYNAME}</gpg.keyname>
+                <gpg.executable>gpg2</gpg.executable>
+                <gpg.passphrase>${env.MAVEN_GPG_PASSWORD}</gpg.passphrase>
+            </properties>
+        </profile>
+    </profiles>
+</settings>


### PR DESCRIPTION
- Rename our maven `artifactId` to `asana` instead of `java-asana`
- Add missing metadata from `pom.xml` so that we can deploy to maven
- Add `settings.xml` which uses environment variables to authenticate to maven and PGP sign our releases

To deploy, simply run `mvn deploy -P release --settings settings.xml`. I've also updated the README.