### PR TITLE
set source encoding to prevent platform dependent build warning http:…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,10 @@
         </developer>
     </developers>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
…//maven.apache.org/general.html#encoding-warning