### PR TITLE
Add support for using refresh token on OAuthApp

### DIFF
--- a/src/main/java/com/asana/OAuthApp.java
+++ b/src/main/java/com/asana/OAuthApp.java
@@ -28,13 +28,18 @@ public class OAuthApp {
     }
 
     public OAuthApp(String clientID, String clientSecret, String redirectUri, String accessToken) {
-        this(clientID, clientSecret, redirectUri, accessToken, HTTP_TRANSPORT, JSON_FACTORY);
+        this(clientID, clientSecret, redirectUri, accessToken, null, HTTP_TRANSPORT, JSON_FACTORY);
+    }
+    
+    public OAuthApp(String clientID, String clientSecret, String redirectUri, String accessToken, String refreshToken) {
+        this(clientID, clientSecret, redirectUri, accessToken, refreshToken, HTTP_TRANSPORT, JSON_FACTORY);
     }
 
     public OAuthApp(String clientID,
                     String clientSecret,
                     String redirectUri,
                     String accessToken,
+                    String refreshToken,
                     HttpTransport transport,
                     JsonFactory jsonFactory) {
         this.redirectUri = redirectUri;
@@ -51,7 +56,8 @@ public class OAuthApp {
 
         if (accessToken != null) {
             credential = new Credential(BearerToken.authorizationHeaderAccessMethod())
-                    .setAccessToken(accessToken);
+                    .setAccessToken(accessToken)
+                    .setRefreshToken(refreshToken);
         }
     }
 


### PR DESCRIPTION
This pull request adds the possibility to pass in a refresh token alongside the access-token, when creating an OAuthApp.

This is useful when the access and refresh token pair was previously fetched and stored for later usage. Currenlty, the OAuthApp provides an easy way of creating a Dispatcher based on such an access-token, but the refresh-token is not taken into account - so the auto-refresh of the token by the Google Auth flow won't kick in.

Current workaround is by using a custom Dispatcher implementation that uses a `com.google.api.client.auth.oauth2.Credential` instance including the refresh token. Would be nice to use the OAuthApp out of the box.