### PR TITLE
fix how OAuthApp builds Credential

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.asana</groupId>
     <artifactId>asana</artifactId>
     <packaging>jar</packaging>
-    <version>0.5.0</version>
+    <version>0.5.1</version>
     <url>http://maven.apache.org</url>
     <name>java-asana</name>
     <description>A Java client for the Asana API.</description>

--- a/src/main/java/com/asana/OAuthApp.java
+++ b/src/main/java/com/asana/OAuthApp.java
@@ -58,7 +58,7 @@ public class OAuthApp {
                 AUTHORIZATION_SERVER_URL
         ).build();
 
-        if (accessToken != null) {
+        if (accessToken != null || refreshToken != null) {
             this.credential = new Credential.Builder(BearerToken.authorizationHeaderAccessMethod())
                 .setTransport(transport)
                 .setJsonFactory(jsonFactory)

--- a/src/main/java/com/asana/OAuthApp.java
+++ b/src/main/java/com/asana/OAuthApp.java
@@ -44,20 +44,30 @@ public class OAuthApp {
                     JsonFactory jsonFactory) {
         this.redirectUri = redirectUri;
 
+        GenericUrl tokenServerUrl = new GenericUrl(TOKEN_SERVER_URL);
+        ClientParametersAuthentication clientAuthentication = new ClientParametersAuthentication(clientID, clientSecret);
+
+
         this.flow = new AuthorizationCodeFlow.Builder(
                 BearerToken.authorizationHeaderAccessMethod(),
                 transport,
                 jsonFactory,
-                new GenericUrl(TOKEN_SERVER_URL),
-                new ClientParametersAuthentication(clientID, clientSecret),
+                tokenServerUrl,
+                clientAuthentication,
                 clientID,
                 AUTHORIZATION_SERVER_URL
         ).build();
 
         if (accessToken != null) {
-            credential = new Credential(BearerToken.authorizationHeaderAccessMethod())
-                    .setAccessToken(accessToken)
-                    .setRefreshToken(refreshToken);
+            this.credential = new Credential.Builder(BearerToken.authorizationHeaderAccessMethod())
+                .setTransport(transport)
+                .setJsonFactory(jsonFactory)
+                .setClientAuthentication(clientAuthentication)
+                .setTokenServerUrl(tokenServerUrl)
+                .build();
+
+            this.credential.setAccessToken(accessToken);
+            this.credential.setRefreshToken(refreshToken);
         }
     }
 


### PR DESCRIPTION
fixes #41 and:
  * makes `OAuthApp` respect the `HttpTransport`/`JsonFactory` arguments on its constructor.  (currently, they're ignored and it uses Credential's default values)
  * supports constructing `OAuthApp` with a `refresh_token`, but no `access_token`, which is a use-case `Credential` supports, as it can use the `refresh_token` to get a valid `access_token`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/182694757934856/218567141908010)
