### PR TITLE
Attempt 2 to get custom fields in Java client library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.asana</groupId>
     <artifactId>asana</artifactId>
     <packaging>jar</packaging>
-    <version>0.5.0</version>
+    <version>0.5.1</version>
     <url>http://maven.apache.org</url>
     <name>java-asana</name>
     <description>A Java client for the Asana API.</description>

--- a/src/main/java/com/asana/Client.java
+++ b/src/main/java/com/asana/Client.java
@@ -48,6 +48,8 @@ public class Client {
     public Dispatcher dispatcher;
 
     public Attachments attachments;
+    public CustomFields custom_fields;
+    public CustomFieldSettings custom_field_settings;
     public Events events;
     public Projects projects;
     public Stories stories;
@@ -85,6 +87,8 @@ public class Client {
         }
 
         this.attachments = new Attachments(this);
+        this.custom_fields = new CustomFields(this);
+        this.custom_field_settings = new CustomFieldSettings(this);
         this.events = new Events(this);
         this.projects = new Projects(this);
         this.stories = new Stories(this);

--- a/src/main/java/com/asana/models/CustomField.java
+++ b/src/main/java/com/asana/models/CustomField.java
@@ -1,14 +1,13 @@
 package com.asana.models;
 
-import com.google.api.client.util.DateTime;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.Collection;
 
 public class CustomField {
 
-    public static class EnumOptions {
-      public Integer id;
+    public static class EnumOption {
+      public String id;
       public String name;
       public Boolean enabled;
       public String color;
@@ -16,9 +15,6 @@ public class CustomField {
 
 
     public String id;
-    @SerializedName("created_at")
-    public DateTime createdAt;
-
     public String name;
     public String type;
 
@@ -26,6 +22,6 @@ public class CustomField {
     public Integer precision;
     // Only for type "enum"
     @SerializedName("enum_options")
-    public EnumOptions enumOptions;
+    public Collection<EnumOption> enumOptions;
 
 }

--- a/src/main/java/com/asana/models/CustomFieldSetting.java
+++ b/src/main/java/com/asana/models/CustomFieldSetting.java
@@ -1,23 +1,18 @@
 package com.asana.models;
 
-import com.google.api.client.util.DateTime;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.Collection;
 
 public class CustomFieldSetting {
 
-    
-
-
     public String id;
-    @SerializedName("created_at")
-    public DateTime createdAt;
     @SerializedName("is_important")
     public Boolean isImportant;
 
     public Project project;
-    public CustomField customField;
 
+    @SerializedName("custom_field")
+    public CustomField customField;
 
 }

--- a/src/main/java/com/asana/models/Project.java
+++ b/src/main/java/com/asana/models/Project.java
@@ -22,6 +22,9 @@ public class Project {
     public Team team;
     public Workspace workspace;
 
+    @SerializedName("custom_field_settings")
+    public Collection<CustomFieldSetting> customFieldSettings;
+
     @SerializedName("created_at")
     public DateTime createdAt;
     @SerializedName("modified_at")


### PR DESCRIPTION
The basic problem here was that there are *resources* and there are *models*, and the models in all the other client libraries are called "resources". Here, they're called "models" since they're just a POJO of public attributes for GSON to deserialize into.

So basically we just needed to follow up and add the models into their model-y precursors, Project -> CustomFieldSettings -> CustomField. 

(I also noticed a couple of other errors in putting the resources in the Client class, so you can call things like `client.custom_field.findById`. Ehh, live and learn.