### PR TITLE
Add support for HTTP 402's from API.

### DIFF
--- a/src/main/java/com/asana/errors/AsanaError.java
+++ b/src/main/java/com/asana/errors/AsanaError.java
@@ -21,6 +21,11 @@ public class AsanaError extends IOException {
     public static AsanaError mapException(HttpResponseException exception) throws AsanaError {
         switch (exception.getStatusCode()) {
             case ForbiddenError.STATUS:
+                String constructedErrorMsg = constructMessage("", exception);
+                String premiumOnlyStr = "not available for free";
+                if (constructedErrorMsg != null && constructedErrorMsg.contains(premiumOnlyStr)) {
+                    return new PremiumOnlyError(exception);
+                }
                 return new ForbiddenError(exception);
             case InvalidRequestError.STATUS:
                 return new InvalidRequestError(exception);
@@ -30,6 +35,8 @@ public class AsanaError extends IOException {
                 return new NoAuthorizationError(exception);
             case NotFoundError.STATUS:
                 return new NotFoundError(exception);
+            case PremiumOnlyError.STATUS:
+                return new PremiumOnlyError(exception);
             case RateLimitEnforcedError.STATUS:
                 return new RateLimitEnforcedError(exception);
             case ServerError.STATUS:

--- a/src/main/java/com/asana/errors/AsanaError.java
+++ b/src/main/java/com/asana/errors/AsanaError.java
@@ -23,7 +23,7 @@ public class AsanaError extends IOException {
             case ForbiddenError.STATUS:
                 String constructedErrorMsg = constructMessage("", exception);
                 String premiumOnlyStr = "not available for free";
-                if (constructedErrorMsg != null && constructedErrorMsg.contains(premiumOnlyStr)) {
+                if (constructedErrorMsg.contains(premiumOnlyStr)) {
                     return new PremiumOnlyError(exception);
                 }
                 return new ForbiddenError(exception);

--- a/src/main/java/com/asana/errors/PremiumOnlyError.java
+++ b/src/main/java/com/asana/errors/PremiumOnlyError.java
@@ -1,0 +1,12 @@
+package com.asana.errors;
+
+import com.google.api.client.http.HttpResponseException;
+
+public class PremiumOnlyError extends AsanaError {
+    final public static String MESSAGE = "Payment Required";
+    final public static int STATUS = 402;
+
+    public PremiumOnlyError(HttpResponseException exception) {
+        super(MESSAGE, STATUS, exception);
+    }
+}

--- a/src/test/java/com/asana/ErrorsTest.java
+++ b/src/test/java/com/asana/ErrorsTest.java
@@ -47,4 +47,24 @@ public class ErrorsTest extends AsanaTest
 
         client.users.me().execute();
     }
+
+    @Test(expected = PremiumOnlyError.class)
+    public void testPremiumOnlyError402() throws IOException
+    {
+        // Handles actual 402 errors
+        dispatcher.registerResponse("GET", "http://app/users/me").code(402).content(
+              "{ \"errors\": [ { \"message\": \"Custom Fields are not available for free users or guests.\" } ] }");
+
+        client.users.me().execute();
+    }
+
+    @Test(expected = PremiumOnlyError.class)
+    public void testPremiumOnlyError403() throws IOException
+    {
+        // Handles 403 errors with a premium message
+        dispatcher.registerResponse("GET", "http://app/users/me").code(403).content(
+              "{ \"errors\": [ { \"message\": \"Custom Fields are not available for free users or guests.\" } ] }");
+
+        client.users.me().execute();
+    }
 }


### PR DESCRIPTION
* Handles for API V1.0 still returning 403's for premium only features by matching against text.
* Handles for API V1.1 returning 402's for premium only features.
* Tests