### PR TITLE
Add target field to stories

### DIFF
--- a/src/main/java/com/asana/models/Attachment.java
+++ b/src/main/java/com/asana/models/Attachment.java
@@ -1,6 +1,5 @@
 package com.asana.models;
 
-public class Attachment {
-    public String id;
+public class Attachment extends Resource {
     public String name;
 }

--- a/src/main/java/com/asana/models/CustomField.java
+++ b/src/main/java/com/asana/models/CustomField.java
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName;
 
 import java.util.Collection;
 
-public class CustomField {
+public class CustomField extends Resource {
 
     public static class EnumOption {
       public String id;
@@ -14,7 +14,6 @@ public class CustomField {
     }
 
 
-    public String id;
     public String name;
     public String type;
 

--- a/src/main/java/com/asana/models/CustomFieldSetting.java
+++ b/src/main/java/com/asana/models/CustomFieldSetting.java
@@ -4,9 +4,8 @@ import com.google.gson.annotations.SerializedName;
 
 import java.util.Collection;
 
-public class CustomFieldSetting {
+public class CustomFieldSetting extends Resource {
 
-    public String id;
     @SerializedName("is_important")
     public Boolean isImportant;
 

--- a/src/main/java/com/asana/models/Event.java
+++ b/src/main/java/com/asana/models/Event.java
@@ -5,8 +5,7 @@ import com.google.gson.annotations.SerializedName;
 import com.google.api.client.util.DateTime;
 
 public class Event {
-    public class Entity {
-        public String id;
+    public class Entity extends Resource {
         public String name;
     }
 

--- a/src/main/java/com/asana/models/Project.java
+++ b/src/main/java/com/asana/models/Project.java
@@ -5,8 +5,7 @@ import com.google.gson.annotations.SerializedName;
 import java.util.Collection;
 import com.google.api.client.util.DateTime;
 
-public class Project {
-    public String id;
+public class Project extends Resource {
     public String name;
 
     public String notes;

--- a/src/main/java/com/asana/models/Resource.java
+++ b/src/main/java/com/asana/models/Resource.java
@@ -1,0 +1,5 @@
+package com.asana.models;
+
+public class Resource {
+    public String id;
+}

--- a/src/main/java/com/asana/models/Story.java
+++ b/src/main/java/com/asana/models/Story.java
@@ -4,10 +4,11 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.api.client.util.DateTime;
 
-public class Story {
-    public String id;
+public class Story extends Resource {
     public String text;
     public String type;
+
+    public Resource target;
 
     @SerializedName("created_by")
     public User createdBy;

--- a/src/main/java/com/asana/models/Tag.java
+++ b/src/main/java/com/asana/models/Tag.java
@@ -5,8 +5,7 @@ import com.google.gson.annotations.SerializedName;
 import java.util.Collection;
 import com.google.api.client.util.DateTime;
 
-public class Tag {
-    public String id;
+public class Tag extends Resource {
     public String name;
     public String notes;
 

--- a/src/main/java/com/asana/models/Task.java
+++ b/src/main/java/com/asana/models/Task.java
@@ -5,7 +5,7 @@ import com.google.gson.annotations.SerializedName;
 
 import java.util.Collection;
 
-public class Task {
+public class Task extends Resource {
     public static class Membership {
         public Project project;
         public Task section;
@@ -16,7 +16,6 @@ public class Task {
         public User user;
     }
 
-    public String id;
     public String name;
     public String notes;
 

--- a/src/main/java/com/asana/models/Team.java
+++ b/src/main/java/com/asana/models/Team.java
@@ -1,7 +1,6 @@
 package com.asana.models;
 
-public class Team {
-    public String id;
+public class Team extends Resource {
     public String name;
 
     public Workspace organization;

--- a/src/main/java/com/asana/models/User.java
+++ b/src/main/java/com/asana/models/User.java
@@ -2,7 +2,7 @@ package com.asana.models;
 
 import java.util.Collection;
 
-public class User {
+public class User extends Resource {
     public static class Photo {
         public String image_128x128;
         public String image_21x21;
@@ -11,7 +11,6 @@ public class User {
         public String image_60x60;
     }
 
-    public String id;
     public String name;
 
     public String email;

--- a/src/main/java/com/asana/models/Webhook.java
+++ b/src/main/java/com/asana/models/Webhook.java
@@ -4,8 +4,7 @@ import com.google.gson.annotations.SerializedName;
 
 import com.google.api.client.util.DateTime;
 
-public class Webhook {
-    public String id;
+public class Webhook extends Resource {
     public Event.Entity resource;
     public String target;
     public boolean active;

--- a/src/main/java/com/asana/models/Workspace.java
+++ b/src/main/java/com/asana/models/Workspace.java
@@ -4,8 +4,7 @@ import com.google.gson.annotations.SerializedName;
 
 import java.util.Collection;
 
-public class Workspace {
-    public String id;
+public class Workspace extends Resource {
     public String name;
 
     @SerializedName("email_domains")


### PR DESCRIPTION
As per [Asana API documentation](https://asana.com/developers/api-reference/stories), `Story` objects have a `target` field. This change exposes those through the Java client library, as a newly created `Resource` model with an `id`. Also, makes all other models inherit from `Resource`.