### PR TITLE
Default to 60 seconds for Retry-After

### DIFF
--- a/src/main/java/com/asana/errors/RateLimitEnforcedError.java
+++ b/src/main/java/com/asana/errors/RateLimitEnforcedError.java
@@ -17,7 +17,7 @@ public class RateLimitEnforcedError extends RetryableAsanaError {
             List<String> headers = (List<String>) exception.getHeaders().get("retry-after");
             retryAfter = (long) (1000 * Float.parseFloat((String) headers.get(0)));
         } catch (Exception e) {
-            retryAfter = -1;
+            retryAfter = 60 * 1000;
         }
     }
 }


### PR DESCRIPTION
In rare cases where an API bug omits this header, default to 60 seconds so that a later call to `Thread.sleep()` doesn't throw an `IllegalArgumentException`.