### PR TITLE
Fix bug in PageIterator (empty collections)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.asana</groupId>
     <artifactId>asana</artifactId>
     <packaging>jar</packaging>
-    <version>0.8.1</version>
+    <version>0.8.2-SNAPSHOT</version>
     <url>http://maven.apache.org</url>
     <name>java-asana</name>
     <description>A Java client for the Asana API.</description>

--- a/src/main/java/com/asana/iterator/PageIterator.java
+++ b/src/main/java/com/asana/iterator/PageIterator.java
@@ -15,46 +15,91 @@ import java.util.NoSuchElementException;
  */
 abstract public class PageIterator<T> implements Iterator<Collection<T>> {
     protected CollectionRequest<T> request;
-    protected long itemLimit;
-    protected long pageSize;
-    protected long count;
+    private final long itemLimit;
+    private final long pageSize;
+    private long count;
     protected Object continuation;
+    private Collection<T> nextData;
+    private IOException ioException;
 
     public PageIterator(CollectionRequest<T> request) {
         this.request = request;
         this.continuation = "";
         this.count = 0;
-        this.pageSize = (Integer) request.options.get("page_size");
-        this.itemLimit = request.options.containsKey("item_limit") ? (Integer) request.options.get("item_limit") : -1;
-        if (this.itemLimit <= 0) {
-            this.itemLimit = Long.MAX_VALUE;
-        }
+        this.pageSize = maxValueIfNullOrNegative((Number) this.request.options.get("page_size"));
+        this.itemLimit = maxValueIfNullOrNegative((Number) this.request.options.get("item_limit"));
     }
 
-    private long currentLimit() {
-        return Math.min(this.pageSize, this.itemLimit - this.count);
+    private static long maxValueIfNullOrNegative(Number number) {
+        long longValue = number == null
+            ? Long.MAX_VALUE
+            : number.longValue();
+        return longValue < 0
+            ? Long.MAX_VALUE
+            : longValue;
+    }
+
+    /**
+     * Retrieve the next page and store the continuation token, the new data, and any IOException that may occur.
+     *
+     * Note that it is safe to pass null values to {@link CollectionRequest#query(String, Object)}. Method
+     * {@link com.asana.Client#request(com.asana.requests.Request)} will not include such options.
+     */
+    private void retrieveNextPage() {
+        if (this.pageSize < Long.MAX_VALUE || this.itemLimit < Long.MAX_VALUE) {
+            this.request.query("limit", Math.min(this.pageSize, this.itemLimit - this.count));
+        } else {
+            this.request.query("limit", null);
+        }
+        ResultBodyCollection<T> page = null;
+        try {
+            page = this.getNext();
+        } catch (IOException exception) {
+            // See comments in hasNext().
+            this.ioException = exception;
+        }
+        if (page != null) {
+            this.continuation = this.getContinuation(page);
+            if (page.data != null && !page.data.isEmpty()) {
+                this.count += page.data.size();
+                this.nextData = page.data;
+            } else {
+                this.nextData = null;
+            }
+        } else {
+            this.continuation = null;
+            this.nextData = null;
+        }
     }
 
     @Override
     public boolean hasNext() {
-        return this.continuation != null && currentLimit() > 0;
+        while (nextData == null && ioException == null && this.continuation != null && this.count < this.itemLimit) {
+            retrieveNextPage();
+        }
+
+        // If an IOException occurred, we return true to indicate another element is available. However, next() will
+        // then throw a NoSuchElementException with the IOException as cause. The motivation for this is keeping the
+        // public API backwards compatible.
+        return nextData != null || ioException != null;
     }
 
     @Override
     public Collection<T> next() throws NoSuchElementException {
-        this.request.query("limit", currentLimit());
-        try {
-            ResultBodyCollection<T> result = this.getNext();
-            this.continuation = this.getContinuation(result);
-            if (result.data != null) {
-                this.count += result.data.size();
-            }
-            return result.data;
-        } catch (IOException error) {
-            NoSuchElementException newError = new NoSuchElementException();
-            newError.initCause(error);
-            throw newError;
+        if (!hasNext()) {
+            throw new NoSuchElementException("No more pages through Asana API.");
+        } else if (ioException != null) {
+            // Wrapping an IOException in a NoSuchElementException is questionable practice, but the API has been this
+            // way since commit 23f13ec from 2015-04-03, so we leave the type for API backwards compatibility.
+            NoSuchElementException newException
+                = new NoSuchElementException("IOException when communicating through Asana API.");
+            newException.initCause(ioException);
+            throw newException;
         }
+
+        Collection<T> currentData = nextData;
+        nextData = null;
+        return currentData;
     }
 
     @Override

--- a/src/test/java/com/asana/IteratorTest.java
+++ b/src/test/java/com/asana/IteratorTest.java
@@ -13,6 +13,18 @@ import java.util.Iterator;
 public class IteratorTest extends AsanaTest
 {
     @Test
+    public void testItemIteratorEmpty() throws IOException
+    {
+        dispatcher.registerResponse("GET", "http://app/projects/1/tasks?limit=2").code(200)
+                .content("{\"data\": []}");
+
+        Iterator<Task> iter = client.tasks.findByProject("1")
+                .option("item_limit", 2).option("page_size", 2)
+                .iterator();
+        assertEquals(false, iter.hasNext());
+    }
+
+    @Test
     public void testItemIteratorItemLimitLessThanItems() throws IOException
     {
         dispatcher.registerResponse("GET", "http://app/projects/1/tasks?limit=2").code(200)
@@ -20,6 +32,29 @@ public class IteratorTest extends AsanaTest
 
         Iterator<Task> iter = client.tasks.findByProject("1")
                 .option("item_limit", 2).option("page_size", 2)
+                .iterator();
+        assertEquals(true, iter.hasNext());
+        assertEquals("1", iter.next().id);
+        assertEquals(true, iter.hasNext());
+        assertEquals("2", iter.next().id);
+        assertEquals(false, iter.hasNext());
+    }
+
+    @Test
+    public void testItemIteratorEmptyPage() throws IOException
+    {
+        // As of March 2019, the public API does not specify whether the backend would ever return an empty page after
+        // previously including the "next_page" attribute. In theory, it could be a legitimate response if at the time
+        // of the first request there was another page, but at the time of actually requesting the next page all
+        // remaining items have meanwhile been removed. In the spirit of loose coupling, it is probably good not to
+        // overly rely on backend implementation details and verify this case, too.
+        dispatcher.registerResponse("GET", "http://app/projects/1/tasks?limit=2").code(200)
+                .content("{\"data\": [{\"id\":1},{\"id\":2}],\"next_page\": { \"offset\": \"a\", \"path\": \"/projects/1/tasks?limit=2&offset=a\" }}");
+        dispatcher.registerResponse("GET", "http://app/projects/1/tasks?limit=1&offset=a").code(200)
+                .content("{ \"data\": [], \"next_page\": null }");
+
+        Iterator<Task> iter = client.tasks.findByProject("1")
+                .option("item_limit", 3).option("page_size", 2)
                 .iterator();
         assertEquals(true, iter.hasNext());
         assertEquals("1", iter.next().id);


### PR DESCRIPTION
The hasNext() method was overly optimistic and returned true before
retrieving any result from the server. Therefore, next() could throw
a NoSuchElementException even though hasNext() had returned true.

Before this fix, using a CollectionRequest as an Iterable (typically in
a for-loop) would always trigger a NoSuchElement exception if the server
returned an empty collection. For some entities this is obviously quite
common. E.g., not every task has attachments.