### PR TITLE
[DO NOT MERGE] [FIX] add resource subtype to custom field (Type deprecated)

### DIFF
--- a/src/main/java/com/asana/models/CustomField.java
+++ b/src/main/java/com/asana/models/CustomField.java
@@ -31,4 +31,7 @@ public class CustomField extends Resource {
     public Collection<EnumOption> enumOptions;
     @SerializedName("enum_value")
     public EnumOption enumValue;
+
+    @SerializedName("resource_subtype")
+    public String resourceSubtype;
 }


### PR DESCRIPTION
custom field does not have a resource_subtype. and according to this form post https://forum.asana.com/t/new-task-subtypes-and-better-type-information/32047
all objects now have a ResourceWithSubtype.

 So surely all model would extend ResourceWithSubtype and not resource or have the resource class modified to include sub_type?