### PR TITLE
Rossgrambo openapi conversion conservative

### DIFF
--- a/.swagger-codegen-ignore
+++ b/.swagger-codegen-ignore
@@ -1,0 +1,4 @@
+# Swagger Codegen Ignore
+
+docs/*
+src/test/java/com/asana/resources/gen/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,4 @@ language: java
 dist: trusty
 jdk:
 - oraclejdk8
-- openjdk7
 - openjdk8

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you use [Maven](http://maven.apache.org/) to manage dependencies you can incl
     <dependency>
          <groupId>com.asana</groupId>
          <artifactId>asana</artifactId>
-         <version>0.9.1</version>
+         <version>0.10.0</version>
     </dependency>
 
 Or, you can build the artifact and install it to your local Maven repository:

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.asana</groupId>
     <artifactId>asana</artifactId>
     <packaging>jar</packaging>
-    <version>0.9.1</version>
+    <version>0.10.0</version>
     <url>http://maven.apache.org</url>
     <name>java-asana</name>
     <description>A Java client for the Asana API.</description>
@@ -104,8 +104,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
 

--- a/src/main/java/com/asana/resources/Attachments.java
+++ b/src/main/java/com/asana/resources/Attachments.java
@@ -2,6 +2,7 @@ package com.asana.resources;
 
 import com.asana.Client;
 import com.asana.models.Attachment;
+import com.asana.requests.CollectionRequest;
 import com.asana.requests.ItemRequest;
 import com.asana.resources.gen.AttachmentsBase;
 import com.google.api.client.http.HttpHeaders;
@@ -40,5 +41,29 @@ public class Attachments extends AttachmentsBase {
         String path = String.format("/tasks/%s/attachments", task);
         return new ItemRequest<Attachment>(this, Attachment.class, path, "POST")
                 .data(content);
+    }
+
+    /**
+     * Returns the full record for a single attachment.
+     *
+     * @param  attachment Globally unique identifier for the attachment.
+     * @return Request object
+     */
+    public ItemRequest<Attachment> findById(String attachment) {
+
+        String path = String.format("/attachments/%s", attachment);
+        return new ItemRequest<Attachment>(this, Attachment.class, path, "GET");
+    }
+
+    /**
+     * Returns the compact records for all attachments on the task.
+     *
+     * @param  task Globally unique identifier for the task.
+     * @return Request object
+     */
+    public CollectionRequest<Attachment> findByTask(String task) {
+
+        String path = String.format("/tasks/%s/attachments", task);
+        return new CollectionRequest<Attachment>(this, Attachment.class, path, "GET");
     }
 }

--- a/src/main/java/com/asana/resources/BatchApis.java
+++ b/src/main/java/com/asana/resources/BatchApis.java
@@ -1,0 +1,10 @@
+package com.asana.resources;
+
+import com.asana.Client;
+import com.asana.resources.gen.BatchApiBase;
+
+public class BatchApis extends BatchApiBase {
+    public BatchApis(Client client) {
+        super(client);
+    }
+}

--- a/src/main/java/com/asana/resources/CustomFieldSettings.java
+++ b/src/main/java/com/asana/resources/CustomFieldSettings.java
@@ -1,10 +1,36 @@
 package com.asana.resources;
 
 import com.asana.Client;
+import com.asana.models.CustomFieldSetting;
+import com.asana.requests.CollectionRequest;
 import com.asana.resources.gen.CustomFieldSettingsBase;
 
 public class CustomFieldSettings extends CustomFieldSettingsBase {
     public CustomFieldSettings(Client client) {
         super(client);
+    }
+
+    /**
+     * Returns a list of all of the custom fields settings on a project.
+     *
+     * @param  project The ID of the project for which to list custom field settings
+     * @return Request object
+     */
+    public CollectionRequest<CustomFieldSetting> findByProject(String project) {
+
+        String path = String.format("/projects/%s/custom_field_settings", project);
+        return new CollectionRequest<CustomFieldSetting>(this, CustomFieldSetting.class, path, "GET");
+    }
+
+    /**
+     * Returns a list of all of the custom fields settings on a portfolio.
+     *
+     * @param  portfolio The ID of the portfolio for which to list custom field settings
+     * @return Request object
+     */
+    public CollectionRequest<CustomFieldSetting> findByPortfolio(String portfolio) {
+
+        String path = String.format("/portfolios/%s/custom_field_settings", portfolio);
+        return new CollectionRequest<CustomFieldSetting>(this, CustomFieldSetting.class, path, "GET");
     }
 }

--- a/src/main/java/com/asana/resources/CustomFields.java
+++ b/src/main/java/com/asana/resources/CustomFields.java
@@ -1,10 +1,118 @@
 package com.asana.resources;
 
 import com.asana.Client;
+import com.asana.models.CustomField;
+import com.asana.requests.CollectionRequest;
+import com.asana.requests.ItemRequest;
 import com.asana.resources.gen.CustomFieldsBase;
 
 public class CustomFields extends CustomFieldsBase {
     public CustomFields(Client client) {
         super(client);
     }
+
+    /**
+     * Creates a new custom field in a workspace. Every custom field is required to be created in a specific workspace, and this workspace cannot be changed once set.
+     *
+     * A custom field's `name` must be unique within a workspace and not conflict with names of existing task properties such as 'Due Date' or 'Assignee'. A custom field's `type` must be one of  'text', 'enum', or 'number'.
+     *
+     * Returns the full record of the newly created custom field.
+     *
+     * @return Request object
+     */
+    public ItemRequest<CustomField> create() {
+
+        return new ItemRequest<CustomField>(this, CustomField.class, "/custom_fields", "POST");
+    }
+
+    /**
+     * Returns the complete definition of a custom field's metadata.
+     *
+     * @param  customField Globally unique identifier for the custom field.
+     * @return Request object
+     */
+    public ItemRequest<CustomField> findById(String customField) {
+
+        String path = String.format("/custom_fields/%s", customField);
+        return new ItemRequest<CustomField>(this, CustomField.class, path, "GET");
+    }
+
+    /**
+     * Returns a list of the compact representation of all of the custom fields in a workspace.
+     *
+     * @param  workspace The workspace or organization to find custom field definitions in.
+     * @return Request object
+     */
+    public CollectionRequest<CustomField> findByWorkspace(String workspace) {
+
+        String path = String.format("/workspaces/%s/custom_fields", workspace);
+        return new CollectionRequest<CustomField>(this, CustomField.class, path, "GET");
+    }
+
+    /**
+     * A specific, existing custom field can be updated by making a PUT request on the URL for that custom field. Only the fields provided in the `data` block will be updated; any unspecified fields will remain unchanged
+     *
+     * When using this method, it is best to specify only those fields you wish to change, or else you may overwrite changes made by another user since you last retrieved the custom field.
+     *
+     * An enum custom field's `enum_options` cannot be updated with this endpoint. Instead see "Work With Enum Options" for information on how to update `enum_options`.
+     *
+     * Locked custom fields can only be updated by the user who locked the field.
+     *
+     * Returns the complete updated custom field record.
+     *
+     * @param  customField Globally unique identifier for the custom field.
+     * @return Request object
+     */
+    public ItemRequest<CustomField> update(String customField) {
+
+        String path = String.format("/custom_fields/%s", customField);
+        return new ItemRequest<CustomField>(this, CustomField.class, path, "PUT");
+    }
+
+    /**
+     * A specific, existing custom field can be deleted by making a DELETE request on the URL for that custom field.
+     *
+     * Locked custom fields can only be deleted by the user who locked the field.
+     *
+     * Returns an empty data record.
+     *
+     * @param  customField Globally unique identifier for the custom field.
+     * @return Request object
+     */
+    public ItemRequest<CustomField> delete(String customField) {
+
+        String path = String.format("/custom_fields/%s", customField);
+        return new ItemRequest<CustomField>(this, CustomField.class, path, "DELETE");
+    }
+
+    /**
+     * Creates an enum option and adds it to this custom field's list of enum options. A custom field can have at most 50 enum options (including disabled options). By default new enum options are inserted at the end of a custom field's list.
+     *
+     * Locked custom fields can only have enum options added by the user who locked the field.
+     *
+     * Returns the full record of the newly created enum option.
+     *
+     * @param  customField Globally unique identifier for the custom field.
+     * @return Request object
+     */
+    public ItemRequest<CustomField> createEnumOption(String customField) {
+
+        String path = String.format("/custom_fields/%s/enum_options", customField);
+        return new ItemRequest<CustomField>(this, CustomField.class, path, "POST");
+    }
+
+    /**
+     * Moves a particular enum option to be either before or after another specified enum option in the custom field.
+     *
+     * Locked custom fields can only be reordered by the user who locked the field.
+     *
+     * @param  customField Globally unique identifier for the custom field.
+     * @return Request object
+     */
+    public ItemRequest<CustomField> insertEnumOption(String customField) {
+
+        String path = String.format("/custom_fields/%s/enum_options/insert", customField);
+        return new ItemRequest<CustomField>(this, CustomField.class, path, "POST");
+    }
+
 }

--- a/src/main/java/com/asana/resources/Jobs.java
+++ b/src/main/java/com/asana/resources/Jobs.java
@@ -1,10 +1,24 @@
 package com.asana.resources;
 
 import com.asana.Client;
+import com.asana.models.Job;
+import com.asana.requests.ItemRequest;
 import com.asana.resources.gen.JobsBase;
 
 public class Jobs extends JobsBase {
     public Jobs(Client client) {
         super(client);
+    }
+
+    /**
+     * Returns the complete job record for a single job.
+     *
+     * @param  job The job to get.
+     * @return Request object
+     */
+    public ItemRequest<Job> findById(String job) {
+
+        String path = String.format("/jobs/%s", job);
+        return new ItemRequest<Job>(this, Job.class, path, "GET");
     }
 }

--- a/src/main/java/com/asana/resources/OrganizationExports.java
+++ b/src/main/java/com/asana/resources/OrganizationExports.java
@@ -1,10 +1,35 @@
 package com.asana.resources;
 
 import com.asana.Client;
+import com.asana.models.OrganizationExport;
+import com.asana.requests.ItemRequest;
 import com.asana.resources.gen.OrganizationExportsBase;
 
 public class OrganizationExports extends OrganizationExportsBase {
     public OrganizationExports(Client client) {
         super(client);
+    }
+
+    /**
+     * Returns details of a previously-requested Organization export.
+     *
+     * @param  organizationExport Globally unique identifier for the Organization export.
+     * @return Request object
+     */
+    public ItemRequest<OrganizationExport> findById(String organizationExport) {
+
+        String path = String.format("/organization_exports/%s", organizationExport);
+        return new ItemRequest<OrganizationExport>(this, OrganizationExport.class, path, "GET");
+    }
+
+    /**
+     * This method creates a request to export an Organization. Asana will complete the export at some
+     * point after you create the request.
+     *
+     * @return Request object
+     */
+    public ItemRequest<OrganizationExport> create() {
+
+        return new ItemRequest<OrganizationExport>(this, OrganizationExport.class, "/organization_exports", "POST");
     }
 }

--- a/src/main/java/com/asana/resources/PortfolioMemberships.java
+++ b/src/main/java/com/asana/resources/PortfolioMemberships.java
@@ -1,10 +1,48 @@
 package com.asana.resources;
 
 import com.asana.Client;
+import com.asana.models.PortfolioMembership;
+import com.asana.requests.CollectionRequest;
+import com.asana.requests.ItemRequest;
 import com.asana.resources.gen.PortfolioMembershipsBase;
 
 public class PortfolioMemberships extends PortfolioMembershipsBase {
     public PortfolioMemberships(Client client) {
         super(client);
+    }
+
+    /**
+     * Returns the compact portfolio membership records for the portfolio. You must
+     * specify `portfolio`, `portfolio` and `user`, or `workspace` and `user`.
+     *
+     * @return Request object
+     */
+    public CollectionRequest<PortfolioMembership> findAll() {
+
+        return new CollectionRequest<PortfolioMembership>(this, PortfolioMembership.class, "/portfolio_memberships", "GET");
+    }
+
+    /**
+     * Returns the compact portfolio membership records for the portfolio.
+     *
+     * @param  portfolio The portfolio for which to fetch memberships.
+     * @return Request object
+     */
+    public CollectionRequest<PortfolioMembership> findByPortfolio(String portfolio) {
+
+        String path = String.format("/portfolios/%s/portfolio_memberships", portfolio);
+        return new CollectionRequest<PortfolioMembership>(this, PortfolioMembership.class, path, "GET");
+    }
+
+    /**
+     * Returns the portfolio membership record.
+     *
+     * @param  portfolioMembership Globally unique identifier for the portfolio membership.
+     * @return Request object
+     */
+    public ItemRequest<PortfolioMembership> findById(String portfolioMembership) {
+
+        String path = String.format("/portfolio_memberships/%s", portfolioMembership);
+        return new ItemRequest<PortfolioMembership>(this, PortfolioMembership.class, path, "GET");
     }
 }

--- a/src/main/java/com/asana/resources/Portfolios.java
+++ b/src/main/java/com/asana/resources/Portfolios.java
@@ -1,10 +1,185 @@
 package com.asana.resources;
 
 import com.asana.Client;
+import com.asana.models.Portfolio;
+import com.asana.requests.CollectionRequest;
+import com.asana.requests.ItemRequest;
 import com.asana.resources.gen.PortfoliosBase;
 
 public class Portfolios extends PortfoliosBase {
     public Portfolios(Client client) {
         super(client);
+    }
+    
+    /**
+     * Creates a new portfolio in the given workspace with the supplied name.
+     *
+     * Note that portfolios created in the Asana UI may have some state
+     * (like the "Priority" custom field) which is automatically added to the
+     * portfolio when it is created. Portfolios created via our API will **not**
+     * be created with the same initial state to allow integrations to create
+     * their own starting state on a portfolio.
+     *
+     * @return Request object
+     */
+    public ItemRequest<Portfolio> create() {
+
+        return new ItemRequest<Portfolio>(this, Portfolio.class, "/portfolios", "POST");
+    }
+
+    /**
+     * Returns the complete record for a single portfolio.
+     *
+     * @param  portfolio The portfolio to get.
+     * @return Request object
+     */
+    public ItemRequest<Portfolio> findById(String portfolio) {
+
+        String path = String.format("/portfolios/%s", portfolio);
+        return new ItemRequest<Portfolio>(this, Portfolio.class, path, "GET");
+    }
+
+    /**
+     * An existing portfolio can be updated by making a PUT request on the
+     * URL for that portfolio. Only the fields provided in the `data` block will be
+     * updated; any unspecified fields will remain unchanged.
+     *
+     * Returns the complete updated portfolio record.
+     *
+     * @param  portfolio The portfolio to update.
+     * @return Request object
+     */
+    public ItemRequest<Portfolio> update(String portfolio) {
+
+        String path = String.format("/portfolios/%s", portfolio);
+        return new ItemRequest<Portfolio>(this, Portfolio.class, path, "PUT");
+    }
+
+    /**
+     * An existing portfolio can be deleted by making a DELETE request
+     * on the URL for that portfolio.
+     *
+     * Returns an empty data record.
+     *
+     * @param  portfolio The portfolio to delete.
+     * @return Request object
+     */
+    public ItemRequest<Portfolio> delete(String portfolio) {
+
+        String path = String.format("/portfolios/%s", portfolio);
+        return new ItemRequest<Portfolio>(this, Portfolio.class, path, "DELETE");
+    }
+
+    /**
+     * Returns a list of the portfolios in compact representation that are owned
+     * by the current API user.
+     *
+     * @return Request object
+     */
+    public CollectionRequest<Portfolio> findAll() {
+
+        return new CollectionRequest<Portfolio>(this, Portfolio.class, "/portfolios", "GET");
+    }
+
+    /**
+     * Get a list of the items in compact form in a portfolio.
+     *
+     * @param  portfolio The portfolio from which to get the list of items.
+     * @return Request object
+     */
+    public CollectionRequest<Resource> getItems(String portfolio) {
+
+        String path = String.format("/portfolios/%s/items", portfolio);
+        return new CollectionRequest<Resource>(this, Resource.class, path, "GET");
+    }
+
+    /**
+     * Add an item to a portfolio.
+     *
+     * Returns an empty data block.
+     *
+     * @param  portfolio The portfolio to which to add an item.
+     * @return Request object
+     */
+    public ItemRequest<Portfolio> addItem(String portfolio) {
+
+        String path = String.format("/portfolios/%s/addItem", portfolio);
+        return new ItemRequest<Portfolio>(this, Portfolio.class, path, "POST");
+    }
+
+    /**
+     * Remove an item to a portfolio.
+     *
+     * Returns an empty data block.
+     *
+     * @param  portfolio The portfolio from which to remove the item.
+     * @return Request object
+     */
+    public ItemRequest<Portfolio> removeItem(String portfolio) {
+
+        String path = String.format("/portfolios/%s/removeItem", portfolio);
+        return new ItemRequest<Portfolio>(this, Portfolio.class, path, "POST");
+    }
+
+    /**
+     * Adds the specified list of users as members of the portfolio. Returns the updated portfolio record.
+     *
+     * @param  portfolio The portfolio to add members to.
+     * @return Request object
+     */
+    public ItemRequest<Portfolio> addMembers(String portfolio) {
+
+        String path = String.format("/portfolios/%s/addMembers", portfolio);
+        return new ItemRequest<Portfolio>(this, Portfolio.class, path, "POST");
+    }
+
+    /**
+     * Removes the specified list of members from the portfolio. Returns the updated portfolio record.
+     *
+     * @param  portfolio The portfolio to remove members from.
+     * @return Request object
+     */
+    public ItemRequest<Portfolio> removeMembers(String portfolio) {
+
+        String path = String.format("/portfolios/%s/removeMembers", portfolio);
+        return new ItemRequest<Portfolio>(this, Portfolio.class, path, "POST");
+    }
+
+    /**
+     * Get the custom field settings on a portfolio.
+     *
+     * @param  portfolio The portfolio from which to get the custom field settings.
+     * @return Request object
+     */
+    public CollectionRequest<Portfolio> customFieldSettings(String portfolio) {
+
+        String path = String.format("/portfolios/%s/custom_field_settings", portfolio);
+        return new CollectionRequest<Portfolio>(this, Portfolio.class, path, "GET");
+    }
+
+    /**
+     * Create a new custom field setting on the portfolio. Returns the full
+     * record for the new custom field setting.
+     *
+     * @param  portfolio The portfolio onto which to add the custom field.
+     * @return Request object
+     */
+    public ItemRequest<Portfolio> addCustomFieldSetting(String portfolio) {
+
+        String path = String.format("/portfolios/%s/addCustomFieldSetting", portfolio);
+        return new ItemRequest<Portfolio>(this, Portfolio.class, path, "POST");
+    }
+
+    /**
+     * Remove a custom field setting on the portfolio. Returns an empty data
+     * block.
+     *
+     * @param  portfolio The portfolio from which to remove the custom field.
+     * @return Request object
+     */
+    public ItemRequest<Portfolio> removeCustomFieldSetting(String portfolio) {
+
+        String path = String.format("/portfolios/%s/removeCustomFieldSetting", portfolio);
+        return new ItemRequest<Portfolio>(this, Portfolio.class, path, "POST");
     }
 }

--- a/src/main/java/com/asana/resources/ProjectMemberships.java
+++ b/src/main/java/com/asana/resources/ProjectMemberships.java
@@ -1,10 +1,37 @@
 package com.asana.resources;
 
 import com.asana.Client;
+import com.asana.models.ProjectMembership;
+import com.asana.requests.CollectionRequest;
+import com.asana.requests.ItemRequest;
 import com.asana.resources.gen.ProjectMembershipsBase;
 
 public class ProjectMemberships extends ProjectMembershipsBase {
     public ProjectMemberships(Client client) {
         super(client);
+    }
+
+    /**
+     * Returns the compact project membership records for the project.
+     *
+     * @param  project The project for which to fetch memberships.
+     * @return Request object
+     */
+    public CollectionRequest<ProjectMembership> findByProject(String project) {
+
+        String path = String.format("/projects/%s/project_memberships", project);
+        return new CollectionRequest<ProjectMembership>(this, ProjectMembership.class, path, "GET");
+    }
+
+    /**
+     * Returns the project membership record.
+     *
+     * @param  projectMembership Globally unique identifier for the project membership.
+     * @return Request object
+     */
+    public ItemRequest<ProjectMembership> findById(String projectMembership) {
+
+        String path = String.format("/project_memberships/%s", projectMembership);
+        return new ItemRequest<ProjectMembership>(this, ProjectMembership.class, path, "GET");
     }
 }

--- a/src/main/java/com/asana/resources/ProjectStatuses.java
+++ b/src/main/java/com/asana/resources/ProjectStatuses.java
@@ -1,10 +1,65 @@
 package com.asana.resources;
 
 import com.asana.Client;
+import com.asana.models.ProjectStatus;
+import com.asana.requests.CollectionRequest;
+import com.asana.requests.ItemRequest;
 import com.asana.resources.gen.ProjectStatusesBase;
 
 public class ProjectStatuses extends ProjectStatusesBase {
     public ProjectStatuses(Client client) {
         super(client);
+    }
+
+    /**
+     * Creates a new status update on the project.
+     *
+     * Returns the full record of the newly created project status update.
+     *
+     * @param  project The project on which to create a status update.
+     * @return Request object
+     */
+    public ItemRequest<ProjectStatus> createInProject(String project) {
+
+        String path = String.format("/projects/%s/project_statuses", project);
+        return new ItemRequest<ProjectStatus>(this, ProjectStatus.class, path, "POST");
+    }
+
+    /**
+     * Returns the compact project status update records for all updates on the project.
+     *
+     * @param  project The project to find status updates for.
+     * @return Request object
+     */
+    public CollectionRequest<ProjectStatus> findByProject(String project) {
+
+        String path = String.format("/projects/%s/project_statuses", project);
+        return new CollectionRequest<ProjectStatus>(this, ProjectStatus.class, path, "GET");
+    }
+
+    /**
+     * Returns the complete record for a single status update.
+     *
+     * @param  projectStatus The project status update to get.
+     * @return Request object
+     */
+    public ItemRequest<ProjectStatus> findById(String projectStatus) {
+
+        String path = String.format("/project_statuses/%s", projectStatus);
+        return new ItemRequest<ProjectStatus>(this, ProjectStatus.class, path, "GET");
+    }
+
+    /**
+     * Deletes a specific, existing project status update.
+     *
+     * Returns an empty data record.
+     *
+     * @param  projectStatus The project status update to delete.
+     * @return Request object
+     */
+    public ItemRequest<ProjectStatus> delete(String projectStatus) {
+
+        String path = String.format("/project_statuses/%s", projectStatus);
+        return new ItemRequest<ProjectStatus>(this, ProjectStatus.class, path, "DELETE");
     }
 }

--- a/src/main/java/com/asana/resources/Projects.java
+++ b/src/main/java/com/asana/resources/Projects.java
@@ -1,10 +1,232 @@
 package com.asana.resources;
 
 import com.asana.Client;
+import com.asana.models.Project;
+import com.asana.requests.CollectionRequest;
+import com.asana.requests.ItemRequest;
 import com.asana.resources.gen.ProjectsBase;
 
 public class Projects extends ProjectsBase {
     public Projects(Client client) {
         super(client);
+    }
+
+    /**
+     * Creates a new project in a workspace or team.
+     *
+     * Every project is required to be created in a specific workspace or
+     * organization, and this cannot be changed once set. Note that you can use
+     * the `workspace` parameter regardless of whether or not it is an
+     * organization.
+     *
+     * If the workspace for your project _is_ an organization, you must also
+     * supply a `team` to share the project with.
+     *
+     * Returns the full record of the newly created project.
+     *
+     * @return Request object
+     */
+    public ItemRequest<Project> create() {
+
+        return new ItemRequest<Project>(this, Project.class, "/projects", "POST");
+    }
+
+    /**
+     * If the workspace for your project _is_ an organization, you must also
+     * supply a `team` to share the project with.
+     *
+     * Returns the full record of the newly created project.
+     *
+     * @param  workspace The workspace or organization to create the project in.
+     * @return Request object
+     */
+    public ItemRequest<Project> createInWorkspace(String workspace) {
+
+        String path = String.format("/workspaces/%s/projects", workspace);
+        return new ItemRequest<Project>(this, Project.class, path, "POST");
+    }
+
+    /**
+     * Creates a project shared with the given team.
+     *
+     * Returns the full record of the newly created project.
+     *
+     * @param  team The team to create the project in.
+     * @return Request object
+     */
+    public ItemRequest<Project> createInTeam(String team) {
+
+        String path = String.format("/teams/%s/projects", team);
+        return new ItemRequest<Project>(this, Project.class, path, "POST");
+    }
+
+    /**
+     * Returns the complete project record for a single project.
+     *
+     * @param  project The project to get.
+     * @return Request object
+     */
+    public ItemRequest<Project> findById(String project) {
+
+        String path = String.format("/projects/%s", project);
+        return new ItemRequest<Project>(this, Project.class, path, "GET");
+    }
+
+    /**
+     * A specific, existing project can be updated by making a PUT request on the
+     * URL for that project. Only the fields provided in the `data` block will be
+     * updated; any unspecified fields will remain unchanged.
+     *
+     * When using this method, it is best to specify only those fields you wish
+     * to change, or else you may overwrite changes made by another user since
+     * you last retrieved the task.
+     *
+     * Returns the complete updated project record.
+     *
+     * @param  project The project to update.
+     * @return Request object
+     */
+    public ItemRequest<Project> update(String project) {
+
+        String path = String.format("/projects/%s", project);
+        return new ItemRequest<Project>(this, Project.class, path, "PUT");
+    }
+
+    /**
+     * A specific, existing project can be deleted by making a DELETE request
+     * on the URL for that project.
+     *
+     * Returns an empty data record.
+     *
+     * @param  project The project to delete.
+     * @return Request object
+     */
+    public ItemRequest<Project> delete(String project) {
+
+        String path = String.format("/projects/%s", project);
+        return new ItemRequest<Project>(this, Project.class, path, "DELETE");
+    }
+
+    /**
+     * Returns the compact project records for some filtered set of projects.
+     * Use one or more of the parameters provided to filter the projects returned.
+     *
+     * @return Request object
+     */
+    public CollectionRequest<Project> findAll() {
+
+        return new CollectionRequest<Project>(this, Project.class, "/projects", "GET");
+    }
+
+    /**
+     * Returns the compact project records for all projects in the workspace.
+     *
+     * @param  workspace The workspace or organization to find projects in.
+     * @return Request object
+     */
+    public CollectionRequest<Project> findByWorkspace(String workspace) {
+
+        String path = String.format("/workspaces/%s/projects", workspace);
+        return new CollectionRequest<Project>(this, Project.class, path, "GET");
+    }
+
+    /**
+     * Returns the compact project records for all projects in the team.
+     *
+     * @param  team The team to find projects in.
+     * @return Request object
+     */
+    public CollectionRequest<Project> findByTeam(String team) {
+
+        String path = String.format("/teams/%s/projects", team);
+        return new CollectionRequest<Project>(this, Project.class, path, "GET");
+    }
+
+    /**
+     * Returns the compact task records for all tasks within the given project,
+     * ordered by their priority within the project. Tasks can exist in more than one project at a time.
+     *
+     * @param  project The project in which to search for tasks.
+     * @return Request object
+     */
+    public CollectionRequest<Project> tasks(String project) {
+
+        String path = String.format("/projects/%s/tasks", project);
+        return new CollectionRequest<Project>(this, Project.class, path, "GET");
+    }
+
+    /**
+     * Adds the specified list of users as followers to the project. Followers are a subset of members, therefore if
+     * the users are not already members of the project they will also become members as a result of this operation.
+     * Returns the updated project record.
+     *
+     * @param  project The project to add followers to.
+     * @return Request object
+     */
+    public ItemRequest<Project> addFollowers(String project) {
+
+        String path = String.format("/projects/%s/addFollowers", project);
+        return new ItemRequest<Project>(this, Project.class, path, "POST");
+    }
+
+    /**
+     * Removes the specified list of users from following the project, this will not affect project membership status.
+     * Returns the updated project record.
+     *
+     * @param  project The project to remove followers from.
+     * @return Request object
+     */
+    public ItemRequest<Project> removeFollowers(String project) {
+
+        String path = String.format("/projects/%s/removeFollowers", project);
+        return new ItemRequest<Project>(this, Project.class, path, "POST");
+    }
+
+    /**
+     * Adds the specified list of users as members of the project. Returns the updated project record.
+     *
+     * @param  project The project to add members to.
+     * @return Request object
+     */
+    public ItemRequest<Project> addMembers(String project) {
+
+        String path = String.format("/projects/%s/addMembers", project);
+        return new ItemRequest<Project>(this, Project.class, path, "POST");
+    }
+
+    /**
+     * Removes the specified list of members from the project. Returns the updated project record.
+     *
+     * @param  project The project to remove members from.
+     * @return Request object
+     */
+    public ItemRequest<Project> removeMembers(String project) {
+
+        String path = String.format("/projects/%s/removeMembers", project);
+        return new ItemRequest<Project>(this, Project.class, path, "POST");
+    }
+
+    /**
+     * Create a new custom field setting on the project.
+     *
+     * @param  project The project to associate the custom field with
+     * @return Request object
+     */
+    public ItemRequest<Project> addCustomFieldSetting(String project) {
+
+        String path = String.format("/projects/%s/addCustomFieldSetting", project);
+        return new ItemRequest<Project>(this, Project.class, path, "POST");
+    }
+
+    /**
+     * Remove a custom field setting on the project.
+     *
+     * @param  project The project to associate the custom field with
+     * @return Request object
+     */
+    public ItemRequest<Project> removeCustomFieldSetting(String project) {
+
+        String path = String.format("/projects/%s/removeCustomFieldSetting", project);
+        return new ItemRequest<Project>(this, Project.class, path, "POST");
     }
 }

--- a/src/main/java/com/asana/resources/Sections.java
+++ b/src/main/java/com/asana/resources/Sections.java
@@ -1,0 +1,126 @@
+package com.asana.resources;
+
+import com.asana.Client;
+import com.asana.models.Section;
+import com.asana.requests.CollectionRequest;
+import com.asana.requests.ItemRequest;
+import com.asana.resources.gen.SectionsBase;
+
+public class Sections extends SectionsBase {
+    public Sections(Client client) {
+        super(client);
+    }
+
+    /**
+     * Creates a new section in a project.
+     *
+     * Returns the full record of the newly created section.
+     *
+     * @param  project The project to create the section in
+     * @return Request object
+     */
+    public ItemRequest<Section> createInProject(String project) {
+
+        String path = String.format("/projects/%s/sections", project);
+        return new ItemRequest<Section>(this, Section.class, path, "POST");
+    }
+
+    /**
+     * Returns the compact records for all sections in the specified project.
+     *
+     * @param  project The project to get sections from.
+     * @return Request object
+     */
+    public CollectionRequest<Section> findByProject(String project) {
+
+        String path = String.format("/projects/%s/sections", project);
+        return new CollectionRequest<Section>(this, Section.class, path, "GET");
+    }
+
+    /**
+     * Returns the complete record for a single section.
+     *
+     * @param  section The section to get.
+     * @return Request object
+     */
+    public ItemRequest<Section> findById(String section) {
+
+        String path = String.format("/sections/%s", section);
+        return new ItemRequest<Section>(this, Section.class, path, "GET");
+    }
+
+    /**
+     * A specific, existing section can be updated by making a PUT request on
+     * the URL for that project. Only the fields provided in the `data` block
+     * will be updated; any unspecified fields will remain unchanged. (note that
+     * at this time, the only field that can be updated is the `name` field.)
+     *
+     * When using this method, it is best to specify only those fields you wish
+     * to change, or else you may overwrite changes made by another user since
+     * you last retrieved the task.
+     *
+     * Returns the complete updated section record.
+     *
+     * @param  section The section to update.
+     * @return Request object
+     */
+    public ItemRequest<Section> update(String section) {
+
+        String path = String.format("/sections/%s", section);
+        return new ItemRequest<Section>(this, Section.class, path, "PUT");
+    }
+
+    /**
+     * A specific, existing section can be deleted by making a DELETE request
+     * on the URL for that section.
+     *
+     * Note that sections must be empty to be deleted.
+     *
+     * The last remaining section in a board view cannot be deleted.
+     *
+     * Returns an empty data block.
+     *
+     * @param  section The section to delete.
+     * @return Request object
+     */
+    public ItemRequest<Section> delete(String section) {
+
+        String path = String.format("/sections/%s", section);
+        return new ItemRequest<Section>(this, Section.class, path, "DELETE");
+    }
+
+    /**
+     * Add a task to a specific, existing section. This will remove the task from other sections of the project.
+     *
+     * The task will be inserted at the top of a section unless an `insert_before` or `insert_after` parameter is declared.
+     *
+     * This does not work for separators (tasks with the `resource_subtype` of section).
+     *
+     * @param  section The section in which to add the task
+     * @return Request object
+     */
+    public ItemRequest<Section> addTask(String section) {
+
+        String path = String.format("/sections/%s/addTask", section);
+        return new ItemRequest<Section>(this, Section.class, path, "POST");
+    }
+
+    /**
+     * Move sections relative to each other in a board view. One of
+     * `before_section` or `after_section` is required.
+     *
+     * Sections cannot be moved between projects.
+     *
+     * At this point in time, moving sections is not supported in list views, only board views.
+     *
+     * Returns an empty data block.
+     *
+     * @param  project The project in which to reorder the given section
+     * @return Request object
+     */
+    public ItemRequest<Section> insertInProject(String project) {
+
+        String path = String.format("/projects/%s/sections/insert", project);
+        return new ItemRequest<Section>(this, Section.class, path, "POST");
+    }
+}

--- a/src/main/java/com/asana/resources/Stories.java
+++ b/src/main/java/com/asana/resources/Stories.java
@@ -1,10 +1,79 @@
 package com.asana.resources;
 
 import com.asana.Client;
+import com.asana.models.Story;
+import com.asana.requests.CollectionRequest;
+import com.asana.requests.ItemRequest;
 import com.asana.resources.gen.StoriesBase;
 
 public class Stories extends StoriesBase {
     public Stories(Client client) {
         super(client);
+    }
+
+    /**
+     * Returns the compact records for all stories on the task.
+     *
+     * @param  task Globally unique identifier for the task.
+     * @return Request object
+     */
+    public CollectionRequest<Story> findByTask(String task) {
+
+        String path = String.format("/tasks/%s/stories", task);
+        return new CollectionRequest<Story>(this, Story.class, path, "GET");
+    }
+
+    /**
+     * Returns the full record for a single story.
+     *
+     * @param  story Globally unique identifier for the story.
+     * @return Request object
+     */
+    public ItemRequest<Story> findById(String story) {
+
+        String path = String.format("/stories/%s", story);
+        return new ItemRequest<Story>(this, Story.class, path, "GET");
+    }
+
+    /**
+     * Adds a comment to a task. The comment will be authored by the
+     * currently authenticated user, and timestamped when the server receives
+     * the request.
+     *
+     * Returns the full record for the new story added to the task.
+     *
+     * @param  task Globally unique identifier for the task.
+     * @return Request object
+     */
+    public ItemRequest<Story> createOnTask(String task) {
+
+        String path = String.format("/tasks/%s/stories", task);
+        return new ItemRequest<Story>(this, Story.class, path, "POST");
+    }
+
+    /**
+     * Updates the story and returns the full record for the updated story.
+     * Only comment stories can have their text updated, and only comment stories and
+     * attachment stories can be pinned. Only one of `text` and `html_text` can be specified.
+     *
+     * @param  story Globally unique identifier for the story.
+     * @return Request object
+     */
+    public ItemRequest<Story> update(String story) {
+
+        String path = String.format("/stories/%s", story);
+        return new ItemRequest<Story>(this, Story.class, path, "PUT");
+    }
+
+    /**
+     * Deletes a story. A user can only delete stories they have created. Returns an empty data record.
+     *
+     * @param  story Globally unique identifier for the story.
+     * @return Request object
+     */
+    public ItemRequest<Story> delete(String story) {
+
+        String path = String.format("/stories/%s", story);
+        return new ItemRequest<Story>(this, Story.class, path, "DELETE");
     }
 }

--- a/src/main/java/com/asana/resources/Tags.java
+++ b/src/main/java/com/asana/resources/Tags.java
@@ -1,10 +1,118 @@
 package com.asana.resources;
 
 import com.asana.Client;
+import com.asana.models.Tag;
+import com.asana.requests.CollectionRequest;
+import com.asana.requests.ItemRequest;
 import com.asana.resources.gen.TagsBase;
 
 public class Tags extends TagsBase {
     public Tags(Client client) {
         super(client);
+    }
+
+    /**
+     * Creates a new tag in a workspace or organization.
+     *
+     * Every tag is required to be created in a specific workspace or
+     * organization, and this cannot be changed once set. Note that you can use
+     * the `workspace` parameter regardless of whether or not it is an
+     * organization.
+     *
+     * Returns the full record of the newly created tag.
+     *
+     * @return Request object
+     */
+    public ItemRequest<Tag> create() {
+
+        return new ItemRequest<Tag>(this, Tag.class, "/tags", "POST");
+    }
+
+    /**
+     * Creates a new tag in a workspace or organization.
+     *
+     * Every tag is required to be created in a specific workspace or
+     * organization, and this cannot be changed once set. Note that you can use
+     * the `workspace` parameter regardless of whether or not it is an
+     * organization.
+     *
+     * Returns the full record of the newly created tag.
+     *
+     * @param  workspace The workspace or organization to create the tag in.
+     * @return Request object
+     */
+    public ItemRequest<Tag> createInWorkspace(String workspace) {
+
+        String path = String.format("/workspaces/%s/tags", workspace);
+        return new ItemRequest<Tag>(this, Tag.class, path, "POST");
+    }
+
+    /**
+     * Returns the complete tag record for a single tag.
+     *
+     * @param  tag The tag to get.
+     * @return Request object
+     */
+    public ItemRequest<Tag> findById(String tag) {
+
+        String path = String.format("/tags/%s", tag);
+        return new ItemRequest<Tag>(this, Tag.class, path, "GET");
+    }
+
+    /**
+     * Updates the properties of a tag. Only the fields provided in the `data`
+     * block will be updated; any unspecified fields will remain unchanged.
+     *
+     * When using this method, it is best to specify only those fields you wish
+     * to change, or else you may overwrite changes made by another user since
+     * you last retrieved the task.
+     *
+     * Returns the complete updated tag record.
+     *
+     * @param  tag The tag to update.
+     * @return Request object
+     */
+    public ItemRequest<Tag> update(String tag) {
+
+        String path = String.format("/tags/%s", tag);
+        return new ItemRequest<Tag>(this, Tag.class, path, "PUT");
+    }
+
+    /**
+     * A specific, existing tag can be deleted by making a DELETE request
+     * on the URL for that tag.
+     *
+     * Returns an empty data record.
+     *
+     * @param  tag The tag to delete.
+     * @return Request object
+     */
+    public ItemRequest<Tag> delete(String tag) {
+
+        String path = String.format("/tags/%s", tag);
+        return new ItemRequest<Tag>(this, Tag.class, path, "DELETE");
+    }
+
+    /**
+     * Returns the compact tag records for some filtered set of tags.
+     * Use one or more of the parameters provided to filter the tags returned.
+     *
+     * @return Request object
+     */
+    public CollectionRequest<Tag> findAll() {
+
+        return new CollectionRequest<Tag>(this, Tag.class, "/tags", "GET");
+    }
+
+    /**
+     * Returns the compact tag records for all tags in the workspace.
+     *
+     * @param  workspace The workspace or organization to find tags in.
+     * @return Request object
+     */
+    public CollectionRequest<Tag> findByWorkspace(String workspace) {
+
+        String path = String.format("/workspaces/%s/tags", workspace);
+        return new CollectionRequest<Tag>(this, Tag.class, path, "GET");
     }
 }

--- a/src/main/java/com/asana/resources/Tasks.java
+++ b/src/main/java/com/asana/resources/Tasks.java
@@ -1,10 +1,462 @@
 package com.asana.resources;
 
 import com.asana.Client;
+import com.asana.models.Job;
+import com.asana.models.Task;
+import com.asana.requests.CollectionRequest;
+import com.asana.requests.ItemRequest;
 import com.asana.resources.gen.TasksBase;
 
 public class Tasks extends TasksBase {
     public Tasks(Client client) {
         super(client);
+    }
+
+    /**
+     * Creating a new task is as easy as POSTing to the `/tasks` endpoint
+     * with a data block containing the fields you'd like to set on the task.
+     * Any unspecified fields will take on default values.
+     *
+     * Every task is required to be created in a specific workspace, and this
+     * workspace cannot be changed once set. The workspace need not be set
+     * explicitly if you specify `projects` or a `parent` task instead.
+     *
+     * `projects` can be a comma separated list of projects, or just a single
+     * project the task should belong to.
+     *
+     * @return Request object
+     */
+    public ItemRequest<Task> create() {
+
+        return new ItemRequest<Task>(this, Task.class, "/tasks", "POST");
+    }
+
+    /**
+     * Creating a new task is as easy as POSTing to the `/tasks` endpoint
+     * with a data block containing the fields you'd like to set on the task.
+     * Any unspecified fields will take on default values.
+     *
+     * Every task is required to be created in a specific workspace, and this
+     * workspace cannot be changed once set. The workspace need not be set
+     * explicitly if you specify a `project` or a `parent` task instead.
+     *
+     * @param  workspace The workspace to create a task in.
+     * @return Request object
+     */
+    public ItemRequest<Task> createInWorkspace(String workspace) {
+
+        String path = String.format("/workspaces/%s/tasks", workspace);
+        return new ItemRequest<Task>(this, Task.class, path, "POST");
+    }
+
+    /**
+     * Returns the complete task record for a single task.
+     *
+     * @param  task The task to get.
+     * @return Request object
+     */
+    public ItemRequest<Task> findById(String task) {
+
+        String path = String.format("/tasks/%s", task);
+        return new ItemRequest<Task>(this, Task.class, path, "GET");
+    }
+
+    /**
+     * A specific, existing task can be updated by making a PUT request on the
+     * URL for that task. Only the fields provided in the `data` block will be
+     * updated; any unspecified fields will remain unchanged.
+     *
+     * When using this method, it is best to specify only those fields you wish
+     * to change, or else you may overwrite changes made by another user since
+     * you last retrieved the task.
+     *
+     * Returns the complete updated task record.
+     *
+     * @param  task The task to update.
+     * @return Request object
+     */
+    public ItemRequest<Task> update(String task) {
+
+        String path = String.format("/tasks/%s", task);
+        return new ItemRequest<Task>(this, Task.class, path, "PUT");
+    }
+
+    /**
+     * A specific, existing task can be deleted by making a DELETE request on the
+     * URL for that task. Deleted tasks go into the "trash" of the user making
+     * the delete request. Tasks can be recovered from the trash within a period
+     * of 30 days; afterward they are completely removed from the system.
+     *
+     * Returns an empty data record.
+     *
+     * @param  task The task to delete.
+     * @return Request object
+     */
+    public ItemRequest<Task> delete(String task) {
+
+        String path = String.format("/tasks/%s", task);
+        return new ItemRequest<Task>(this, Task.class, path, "DELETE");
+    }
+
+    /**
+     * Returns the compact task records for all tasks within the given project,
+     * ordered by their priority within the project.
+     *
+     * @param  project The project in which to search for tasks.
+     * @return Request object
+     */
+    public CollectionRequest<Task> findByProject(String project) {
+
+        String path = String.format("/projects/%s/tasks", project);
+        return new CollectionRequest<Task>(this, Task.class, path, "GET");
+    }
+
+    /**
+     * Returns the compact task records for all tasks with the given tag.
+     *
+     * @param  tag The tag in which to search for tasks.
+     * @return Request object
+     */
+    public CollectionRequest<Task> findByTag(String tag) {
+
+        String path = String.format("/tags/%s/tasks", tag);
+        return new CollectionRequest<Task>(this, Task.class, path, "GET");
+    }
+
+    /**
+     * <b>Board view only:</b> Returns the compact section records for all tasks within the given section.
+     *
+     * @param  section The section in which to search for tasks.
+     * @return Request object
+     */
+    public CollectionRequest<Task> findBySection(String section) {
+
+        String path = String.format("/sections/%s/tasks", section);
+        return new CollectionRequest<Task>(this, Task.class, path, "GET");
+    }
+
+    /**
+     * Returns the compact list of tasks in a user's My Tasks list. The returned
+     * tasks will be in order within each assignee status group of `Inbox`,
+     * `Today`, and `Upcoming`.
+     *
+     * **Note:** tasks in `Later` have a different ordering in the Asana web app
+     * than the other assignee status groups; this endpoint will still return
+     * them in list order in `Later` (differently than they show up in Asana,
+     * but the same order as in Asana's mobile apps).
+     *
+     * **Note:** Access control is enforced for this endpoint as with all Asana
+     * API endpoints, meaning a user's private tasks will be filtered out if the
+     * API-authenticated user does not have access to them.
+     *
+     * **Note:** Both complete and incomplete tasks are returned by default
+     * unless they are filtered out (for example, setting `completed_since=now`
+     * will return only incomplete tasks, which is the default view for "My
+     * Tasks" in Asana.)
+     *
+     * @param  userTaskList The user task list in which to search for tasks.
+     * @return Request object
+     */
+    public CollectionRequest<Task> findByUserTaskList(String userTaskList) {
+
+        String path = String.format("/user_task_lists/%s/tasks", userTaskList);
+        return new CollectionRequest<Task>(this, Task.class, path, "GET");
+    }
+
+    /**
+     * Returns the compact task records for some filtered set of tasks. Use one
+     * or more of the parameters provided to filter the tasks returned. You must
+     * specify a `project`, `section`, `tag`, or `user_task_list` if you do not
+     * specify `assignee` and `workspace`.
+     *
+     * @return Request object
+     */
+    public CollectionRequest<Task> findAll() {
+
+        return new CollectionRequest<Task>(this, Task.class, "/tasks", "GET");
+    }
+
+    /**
+     * Returns the compact task records for all tasks with the given tag.
+     * Tasks can have more than one tag at a time.
+     *
+     * @param  tag The tag to fetch tasks from.
+     * @return Request object
+     */
+    public CollectionRequest<Task> getTasksWithTag(String tag) {
+
+        String path = String.format("/tags/%s/tasks", tag);
+        return new CollectionRequest<Task>(this, Task.class, path, "GET");
+    }
+
+    /**
+     * The search endpoint allows you to build complex queries to find and fetch exactly the data you need from Asana. For a more comprehensive description of all the query parameters and limitations of this endpoint, see our [long-form documentation](/developers/documentation/getting-started/search-api) for this feature.
+     *
+     * @param  workspace The workspace or organization in which to search for tasks.
+     * @return Request object
+     */
+    public CollectionRequest<Task> searchInWorkspace(String workspace) {
+
+        String path = String.format("/workspaces/%s/tasks/search", workspace);
+        return new CollectionRequest<Task>(this, Task.class, path, "GET");
+    }
+
+    /**
+     * Returns the compact representations of all of the dependencies of a task.
+     *
+     * @param  task The task to get dependencies on.
+     * @return Request object
+     */
+    public ItemRequest<Task> dependencies(String task) {
+
+        String path = String.format("/tasks/%s/dependencies", task);
+        return new ItemRequest<Task>(this, Task.class, path, "GET");
+    }
+
+    /**
+     * Returns the compact representations of all of the dependents of a task.
+     *
+     * @param  task The task to get dependents on.
+     * @return Request object
+     */
+    public ItemRequest<Task> dependents(String task) {
+
+        String path = String.format("/tasks/%s/dependents", task);
+        return new ItemRequest<Task>(this, Task.class, path, "GET");
+    }
+
+    /**
+     * Marks a set of tasks as dependencies of this task, if they are not
+     * already dependencies. *A task can have at most 15 dependencies.*
+     *
+     * @param  task The task to add dependencies to.
+     * @return Request object
+     */
+    public ItemRequest<Task> addDependencies(String task) {
+
+        String path = String.format("/tasks/%s/addDependencies", task);
+        return new ItemRequest<Task>(this, Task.class, path, "POST");
+    }
+
+    /**
+     * Marks a set of tasks as dependents of this task, if they are not already
+     * dependents. *A task can have at most 30 dependents.*
+     *
+     * @param  task The task to add dependents to.
+     * @return Request object
+     */
+    public ItemRequest<Task> addDependents(String task) {
+
+        String path = String.format("/tasks/%s/addDependents", task);
+        return new ItemRequest<Task>(this, Task.class, path, "POST");
+    }
+
+    /**
+     * Unlinks a set of dependencies from this task.
+     *
+     * @param  task The task to remove dependencies from.
+     * @return Request object
+     */
+    public ItemRequest<Task> removeDependencies(String task) {
+
+        String path = String.format("/tasks/%s/removeDependencies", task);
+        return new ItemRequest<Task>(this, Task.class, path, "POST");
+    }
+
+    /**
+     * Unlinks a set of dependents from this task.
+     *
+     * @param  task The task to remove dependents from.
+     * @return Request object
+     */
+    public ItemRequest<Task> removeDependents(String task) {
+
+        String path = String.format("/tasks/%s/removeDependents", task);
+        return new ItemRequest<Task>(this, Task.class, path, "POST");
+    }
+
+    /**
+     * Adds each of the specified followers to the task, if they are not already
+     * following. Returns the complete, updated record for the affected task.
+     *
+     * @param  task The task to add followers to.
+     * @return Request object
+     */
+    public ItemRequest<Task> addFollowers(String task) {
+
+        String path = String.format("/tasks/%s/addFollowers", task);
+        return new ItemRequest<Task>(this, Task.class, path, "POST");
+    }
+
+    /**
+     * Removes each of the specified followers from the task if they are
+     * following. Returns the complete, updated record for the affected task.
+     *
+     * @param  task The task to remove followers from.
+     * @return Request object
+     */
+    public ItemRequest<Task> removeFollowers(String task) {
+
+        String path = String.format("/tasks/%s/removeFollowers", task);
+        return new ItemRequest<Task>(this, Task.class, path, "POST");
+    }
+
+    /**
+     * Returns a compact representation of all of the projects the task is in.
+     *
+     * @param  task The task to get projects on.
+     * @return Request object
+     */
+    public CollectionRequest<Task> projects(String task) {
+
+        String path = String.format("/tasks/%s/projects", task);
+        return new CollectionRequest<Task>(this, Task.class, path, "GET");
+    }
+
+    /**
+     * Adds the task to the specified project, in the optional location
+     * specified. If no location arguments are given, the task will be added to
+     * the end of the project.
+     *
+     * `addProject` can also be used to reorder a task within a project or section that
+     * already contains it.
+     *
+     * At most one of `insert_before`, `insert_after`, or `section` should be
+     * specified. Inserting into a section in an non-order-dependent way can be
+     * done by specifying `section`, otherwise, to insert within a section in a
+     * particular place, specify `insert_before` or `insert_after` and a task
+     * within the section to anchor the position of this task.
+     *
+     * Returns an empty data block.
+     *
+     * @param  task The task to add to a project.
+     * @return Request object
+     */
+    public ItemRequest<Task> addProject(String task) {
+
+        String path = String.format("/tasks/%s/addProject", task);
+        return new ItemRequest<Task>(this, Task.class, path, "POST");
+    }
+
+    /**
+     * Removes the task from the specified project. The task will still exist
+     * in the system, but it will not be in the project anymore.
+     *
+     * Returns an empty data block.
+     *
+     * @param  task The task to remove from a project.
+     * @return Request object
+     */
+    public ItemRequest<Task> removeProject(String task) {
+
+        String path = String.format("/tasks/%s/removeProject", task);
+        return new ItemRequest<Task>(this, Task.class, path, "POST");
+    }
+
+    /**
+     * Returns a compact representation of all of the tags the task has.
+     *
+     * @param  task The task to get tags on.
+     * @return Request object
+     */
+    public CollectionRequest<Task> tags(String task) {
+
+        String path = String.format("/tasks/%s/tags", task);
+        return new CollectionRequest<Task>(this, Task.class, path, "GET");
+    }
+
+    /**
+     * Adds a tag to a task. Returns an empty data block.
+     *
+     * @param  task The task to add a tag to.
+     * @return Request object
+     */
+    public ItemRequest<Task> addTag(String task) {
+
+        String path = String.format("/tasks/%s/addTag", task);
+        return new ItemRequest<Task>(this, Task.class, path, "POST");
+    }
+
+    /**
+     * Removes a tag from the task. Returns an empty data block.
+     *
+     * @param  task The task to remove a tag from.
+     * @return Request object
+     */
+    public ItemRequest<Task> removeTag(String task) {
+
+        String path = String.format("/tasks/%s/removeTag", task);
+        return new ItemRequest<Task>(this, Task.class, path, "POST");
+    }
+
+    /**
+     * Returns a compact representation of all of the subtasks of a task.
+     *
+     * @param  task The task to get the subtasks of.
+     * @return Request object
+     */
+    public CollectionRequest<Task> subtasks(String task) {
+
+        String path = String.format("/tasks/%s/subtasks", task);
+        return new CollectionRequest<Task>(this, Task.class, path, "GET");
+    }
+
+    /**
+     * Creates a new subtask and adds it to the parent task. Returns the full record
+     * for the newly created subtask.
+     *
+     * @param  task The task to add a subtask to.
+     * @return Request object
+     */
+    public ItemRequest<Task> addSubtask(String task) {
+
+        String path = String.format("/tasks/%s/subtasks", task);
+        return new ItemRequest<Task>(this, Task.class, path, "POST");
+    }
+
+    /**
+     * Returns a compact representation of all of the stories on the task.
+     *
+     * @param  task The task containing the stories to get.
+     * @return Request object
+     */
+    public CollectionRequest<Task> stories(String task) {
+
+        String path = String.format("/tasks/%s/stories", task);
+        return new CollectionRequest<Task>(this, Task.class, path, "GET");
+    }
+
+    /**
+     * Adds a comment to a task. The comment will be authored by the
+     * currently authenticated user, and timestamped when the server receives
+     * the request.
+     *
+     * Returns the full record for the new story added to the task.
+     *
+     * @param  task Globally unique identifier for the task.
+     * @return Request object
+     */
+    public ItemRequest<Task> addComment(String task) {
+
+        String path = String.format("/tasks/%s/stories", task);
+        return new ItemRequest<Task>(this, Task.class, path, "POST");
+    }
+
+    /**
+     * Insert or reorder tasks in a user's My Tasks list. If the task was not
+     * assigned to the owner of the user task list it will be reassigned when
+     * this endpoint is called. If neither `insert_before` nor `insert_after`
+     * are provided the task will be inserted at the top of the assignee's
+     * inbox.
+     *
+     * Returns an empty data block.
+     *
+     * @param  userTaskList Globally unique identifier for the user task list.
+     * @return Request object
+     */
+    public ItemRequest<Task> insertInUserTaskList(String userTaskList) {
+
+        String path = String.format("/user_task_lists/%s/tasks/insert", userTaskList);
+        return new ItemRequest<Task>(this, Task.class, path, "POST");
     }
 }

--- a/src/main/java/com/asana/resources/TeamMemberships.java
+++ b/src/main/java/com/asana/resources/TeamMemberships.java
@@ -1,0 +1,10 @@
+package com.asana.resources;
+
+import com.asana.Client;
+import com.asana.resources.gen.TeamMembershipsBase;
+
+public class TeamMemberships extends TeamMembershipsBase {
+    public TeamMemberships(Client client) {
+        super(client);
+    }
+}

--- a/src/main/java/com/asana/resources/Teams.java
+++ b/src/main/java/com/asana/resources/Teams.java
@@ -1,10 +1,92 @@
 package com.asana.resources;
 
 import com.asana.Client;
+import com.asana.models.Team;
+import com.asana.requests.CollectionRequest;
+import com.asana.requests.ItemRequest;
 import com.asana.resources.gen.TeamsBase;
 
 public class Teams extends TeamsBase {
     public Teams(Client client) {
         super(client);
+    }
+
+    /**
+     * Returns the full record for a single team.
+     *
+     * @param  team Globally unique identifier for the team.
+     * @return Request object
+     */
+    public ItemRequest<Team> findById(String team) {
+
+        String path = String.format("/teams/%s", team);
+        return new ItemRequest<Team>(this, Team.class, path, "GET");
+    }
+
+    /**
+     * Returns the compact records for all teams in the organization visible to
+     * the authorized user.
+     *
+     * @param  organization Globally unique identifier for the workspace or organization.
+     * @return Request object
+     */
+    public CollectionRequest<Team> findByOrganization(String organization) {
+
+        String path = String.format("/organizations/%s/teams", organization);
+        return new CollectionRequest<Team>(this, Team.class, path, "GET");
+    }
+
+    /**
+     * Returns the compact records for all teams to which user is assigned.
+     *
+     * @param  user An identifier for the user. Can be one of an email address,
+     * the globally unique identifier for the user, or the keyword `me`
+     * to indicate the current user making the request.
+     * @return Request object
+     */
+    public CollectionRequest<Team> findByUser(String user) {
+
+        String path = String.format("/users/%s/teams", user);
+        return new CollectionRequest<Team>(this, Team.class, path, "GET");
+    }
+
+    /**
+     * Returns the compact records for all users that are members of the team.
+     *
+     * @param  team Globally unique identifier for the team.
+     * @return Request object
+     */
+    public CollectionRequest<Team> users(String team) {
+
+        String path = String.format("/teams/%s/users", team);
+        return new CollectionRequest<Team>(this, Team.class, path, "GET");
+    }
+
+    /**
+     * The user making this call must be a member of the team in order to add others.
+     * The user to add must exist in the same organization as the team in order to be added.
+     * The user to add can be referenced by their globally unique user ID or their email address.
+     * Returns the full user record for the added user.
+     *
+     * @param  team Globally unique identifier for the team.
+     * @return Request object
+     */
+    public ItemRequest<Team> addUser(String team) {
+
+        String path = String.format("/teams/%s/addUser", team);
+        return new ItemRequest<Team>(this, Team.class, path, "POST");
+    }
+
+    /**
+     * The user to remove can be referenced by their globally unique user ID or their email address.
+     * Removes the user from the specified team. Returns an empty data record.
+     *
+     * @param  team Globally unique identifier for the team.
+     * @return Request object
+     */
+    public ItemRequest<Team> removeUser(String team) {
+
+        String path = String.format("/teams/%s/removeUser", team);
+        return new ItemRequest<Team>(this, Team.class, path, "POST");
     }
 }

--- a/src/main/java/com/asana/resources/Typeahead.java
+++ b/src/main/java/com/asana/resources/Typeahead.java
@@ -1,0 +1,10 @@
+package com.asana.resources;
+
+import com.asana.Client;
+import com.asana.resources.gen.TypeaheadBase;
+
+public class Typeahead extends TypeaheadBase {
+    public Typeahead(Client client) {
+        super(client);
+    }
+}

--- a/src/main/java/com/asana/resources/UserTaskLists.java
+++ b/src/main/java/com/asana/resources/UserTaskLists.java
@@ -1,10 +1,67 @@
 package com.asana.resources;
 
 import com.asana.Client;
+import com.asana.models.UserTaskList;
+import com.asana.requests.CollectionRequest;
+import com.asana.requests.ItemRequest;
 import com.asana.resources.gen.UserTaskListsBase;
 
 public class UserTaskLists extends UserTaskListsBase {
     public UserTaskLists(Client client) {
         super(client);
+    }
+
+    /**
+     * Returns the full record for the user task list for the given user
+     *
+     * @param  user An identifier for the user. Can be one of an email address,
+     * the globally unique identifier for the user, or the keyword `me`
+     * to indicate the current user making the request.
+     * @return Request object
+     */
+    public ItemRequest<UserTaskList> findByUser(String user) {
+
+        String path = String.format("/users/%s/user_task_list", user);
+        return new ItemRequest<UserTaskList>(this, UserTaskList.class, path, "GET");
+    }
+
+    /**
+     * Returns the full record for a user task list.
+     *
+     * @param  userTaskList Globally unique identifier for the user task list.
+     * @return Request object
+     */
+    public ItemRequest<UserTaskList> findById(String userTaskList) {
+
+        String path = String.format("/user_task_lists/%s", userTaskList);
+        return new ItemRequest<UserTaskList>(this, UserTaskList.class, path, "GET");
+    }
+
+    /**
+     * Returns the compact list of tasks in a user's My Tasks list. The returned
+     * tasks will be in order within each assignee status group of `Inbox`,
+     * `Today`, and `Upcoming`.
+     *
+     * **Note:** tasks in `Later` have a different ordering in the Asana web app
+     * than the other assignee status groups; this endpoint will still return
+     * them in list order in `Later` (differently than they show up in Asana,
+     * but the same order as in Asana's mobile apps).
+     *
+     * **Note:** Access control is enforced for this endpoint as with all Asana
+     * API endpoints, meaning a user's private tasks will be filtered out if the
+     * API-authenticated user does not have access to them.
+     *
+     * **Note:** Both complete and incomplete tasks are returned by default
+     * unless they are filtered out (for example, setting `completed_since=now`
+     * will return only incomplete tasks, which is the default view for "My
+     * Tasks" in Asana.)
+     *
+     * @param  userTaskList The user task list in which to search for tasks.
+     * @return Request object
+     */
+    public CollectionRequest<UserTaskList> tasks(String userTaskList) {
+
+        String path = String.format("/user_task_lists/%s/tasks", userTaskList);
+        return new CollectionRequest<UserTaskList>(this, UserTaskList.class, path, "GET");
     }
 }

--- a/src/main/java/com/asana/resources/Users.java
+++ b/src/main/java/com/asana/resources/Users.java
@@ -1,10 +1,78 @@
 package com.asana.resources;
 
 import com.asana.Client;
+import com.asana.models.ResourceWithSubtype;
+import com.asana.models.User;
+import com.asana.requests.CollectionRequest;
+import com.asana.requests.ItemRequest;
 import com.asana.resources.gen.UsersBase;
 
 public class Users extends UsersBase {
     public Users(Client client) {
         super(client);
+    }
+
+    /**
+     * Returns the full user record for the currently authenticated user.
+     *
+     * @return Request object
+     */
+    public ItemRequest<User> me() {
+
+        return new ItemRequest<User>(this, User.class, "/users/me", "GET");
+    }
+
+    /**
+     * Returns the full user record for the single user with the provided ID.
+     *
+     * @param  user An identifier for the user. Can be one of an email address,
+     * the globally unique identifier for the user, or the keyword `me`
+     * to indicate the current user making the request.
+     * @return Request object
+     */
+    public ItemRequest<User> findById(String user) {
+
+        String path = String.format("/users/%s", user);
+        return new ItemRequest<User>(this, User.class, path, "GET");
+    }
+
+    /**
+     * Returns all of a user's favorites in the given workspace, of the given type.
+     * Results are given in order (The same order as Asana's sidebar).
+     *
+     * @param  user An identifier for the user. Can be one of an email address,
+     * the globally unique identifier for the user, or the keyword `me`
+     * to indicate the current user making the request.
+     * @return Request object
+     */
+    public CollectionRequest<ResourceWithSubtype> getUserFavorites(String user) {
+
+        String path = String.format("/users/%s/favorites", user);
+        return new CollectionRequest<ResourceWithSubtype>(this, ResourceWithSubtype.class, path, "GET");
+    }
+
+    /**
+     * Returns the user records for all users in the specified workspace or
+     * organization.
+     *
+     * @param  workspace The workspace in which to get users.
+     * @return Request object
+     */
+    public CollectionRequest<User> findByWorkspace(String workspace) {
+
+        String path = String.format("/workspaces/%s/users", workspace);
+        return new CollectionRequest<User>(this, User.class, path, "GET");
+    }
+
+    /**
+     * Returns the user records for all users in all workspaces and organizations
+     * accessible to the authenticated user. Accepts an optional workspace ID
+     * parameter.
+     *
+     * @return Request object
+     */
+    public CollectionRequest<User> findAll() {
+
+        return new CollectionRequest<User>(this, User.class, "/users", "GET");
     }
 }

--- a/src/main/java/com/asana/resources/Webhooks.java
+++ b/src/main/java/com/asana/resources/Webhooks.java
@@ -1,10 +1,74 @@
 package com.asana.resources;
 
 import com.asana.Client;
+import com.asana.models.Webhook;
+import com.asana.requests.CollectionRequest;
+import com.asana.requests.ItemRequest;
 import com.asana.resources.gen.WebhooksBase;
 
 public class Webhooks extends WebhooksBase {
     public Webhooks(Client client) {
         super(client);
+    }
+
+    /**
+     * Establishing a webhook is a two-part process. First, a simple HTTP POST
+     * similar to any other resource creation. Since you could have multiple
+     * webhooks we recommend specifying a unique local id for each target.
+     *
+     * Next comes the confirmation handshake. When a webhook is created, we will
+     * send a test POST to the `target` with an `X-Hook-Secret` header as
+     * described in the
+     * [Resthooks Security documentation](http://resthooks.org/docs/security/).
+     * The target must respond with a `200 OK` and a matching `X-Hook-Secret`
+     * header to confirm that this webhook subscription is indeed expected.
+     *
+     * If you do not acknowledge the webhook's confirmation handshake it will
+     * fail to setup, and you will receive an error in response to your attempt
+     * to create it. This means you need to be able to receive and complete the
+     * webhook *while* the POST request is in-flight.
+     *
+     * @return Request object
+     */
+    public ItemRequest<Webhook> create() {
+
+        return new ItemRequest<Webhook>(this, Webhook.class, "/webhooks", "POST");
+    }
+
+    /**
+     * Returns the compact representation of all webhooks your app has
+     * registered for the authenticated user in the given workspace.
+     *
+     * @return Request object
+     */
+    public CollectionRequest<Webhook> getAll() {
+
+        return new CollectionRequest<Webhook>(this, Webhook.class, "/webhooks", "GET");
+    }
+
+    /**
+     * Returns the full record for the given webhook.
+     *
+     * @param  webhook The webhook to get.
+     * @return Request object
+     */
+    public ItemRequest<Webhook> getById(String webhook) {
+
+        String path = String.format("/webhooks/%s", webhook);
+        return new ItemRequest<Webhook>(this, Webhook.class, path, "GET");
+    }
+
+    /**
+     * This method permanently removes a webhook. Note that it may be possible
+     * to receive a request that was already in flight after deleting the
+     * webhook, but no further requests will be issued.
+     *
+     * @param  webhook The webhook to delete.
+     * @return Request object
+     */
+    public ItemRequest<Webhook> deleteById(String webhook) {
+
+        String path = String.format("/webhooks/%s", webhook);
+        return new ItemRequest<Webhook>(this, Webhook.class, path, "DELETE");
     }
 }

--- a/src/main/java/com/asana/resources/WorkspaceMemberships.java
+++ b/src/main/java/com/asana/resources/WorkspaceMemberships.java
@@ -1,0 +1,10 @@
+package com.asana.resources;
+
+import com.asana.Client;
+import com.asana.resources.gen.WorkspaceMembershipsBase;
+
+public class WorkspaceMemberships extends WorkspaceMembershipsBase {
+    public WorkspaceMemberships(Client client) {
+        super(client);
+    }
+}

--- a/src/main/java/com/asana/resources/Workspaces.java
+++ b/src/main/java/com/asana/resources/Workspaces.java
@@ -3,6 +3,7 @@ package com.asana.resources;
 import com.asana.Client;
 import com.asana.models.*;
 import com.asana.requests.CollectionRequest;
+import com.asana.requests.ItemRequest;
 import com.asana.resources.gen.WorkspacesBase;
 
 public class Workspaces extends WorkspacesBase {
@@ -32,5 +33,87 @@ public class Workspaces extends WorkspacesBase {
         String path = String.format("/workspaces/%s/typeahead", workspace);
         CollectionRequest<Tag> request = new CollectionRequest<>(this, Tag.class, path, "GET");
         return request.query("type", "tag");
+    }
+
+    /**
+     * Returns the full workspace record for a single workspace.
+     *
+     * @param  workspace Globally unique identifier for the workspace or organization.
+     * @return Request object
+     */
+    public ItemRequest<Workspace> findById(String workspace) {
+
+        String path = String.format("/workspaces/%s", workspace);
+        return new ItemRequest<Workspace>(this, Workspace.class, path, "GET");
+    }
+
+    /**
+     * Returns the compact records for all workspaces visible to the authorized user.
+     *
+     * @return Request object
+     */
+    public CollectionRequest<Workspace> findAll() {
+
+        return new CollectionRequest<Workspace>(this, Workspace.class, "/workspaces", "GET");
+    }
+
+    /**
+     * A specific, existing workspace can be updated by making a PUT request on
+     * the URL for that workspace. Only the fields provided in the data block
+     * will be updated; any unspecified fields will remain unchanged.
+     *
+     * Currently the only field that can be modified for a workspace is its `name`.
+     *
+     * Returns the complete, updated workspace record.
+     *
+     * @param  workspace The workspace to update.
+     * @return Request object
+     */
+    public ItemRequest<Workspace> update(String workspace) {
+
+        String path = String.format("/workspaces/%s", workspace);
+        return new ItemRequest<Workspace>(this, Workspace.class, path, "PUT");
+    }
+
+    /**
+     * Retrieves objects in the workspace based on an auto-completion/typeahead
+     * search algorithm. This feature is meant to provide results quickly, so do
+     * not rely on this API to provide extremely accurate search results. The
+     * result set is limited to a single page of results with a maximum size,
+     * so you won't be able to fetch large numbers of results.
+     *
+     * @param  workspace The workspace to fetch objects from.
+     * @return Request object
+     */
+    public CollectionRequest<ResourceWithSubtype> typeahead(String workspace) {
+
+        String path = String.format("/workspaces/%s/typeahead", workspace);
+        return new CollectionRequest<ResourceWithSubtype>(this, ResourceWithSubtype.class, path, "GET");
+    }
+
+    /**
+     * The user can be referenced by their globally unique user ID or their email address.
+     * Returns the full user record for the invited user.
+     *
+     * @param  workspace The workspace or organization to invite the user to.
+     * @return Request object
+     */
+    public ItemRequest<Workspace> addUser(String workspace) {
+
+        String path = String.format("/workspaces/%s/addUser", workspace);
+        return new ItemRequest<Workspace>(this, Workspace.class, path, "POST");
+    }
+
+    /**
+     * The user making this call must be an admin in the workspace.
+     * Returns an empty data record.
+     *
+     * @param  workspace The workspace or organization to invite the user to.
+     * @return Request object
+     */
+    public ItemRequest<Workspace> removeUser(String workspace) {
+
+        String path = String.format("/workspaces/%s/removeUser", workspace);
+        return new ItemRequest<Workspace>(this, Workspace.class, path, "POST");
     }
 }

--- a/src/main/java/com/asana/resources/gen/AttachmentsBase.java
+++ b/src/main/java/com/asana/resources/gen/AttachmentsBase.java
@@ -20,32 +20,6 @@ import java.util.List;
     public AttachmentsBase(Client client) { super(client); }
 
         /**
-        * Upload an attachment
-        * Upload an attachment.  This method uploads an attachment to a task and returns the compact record for the created attachment object. It is not possible to attach files from third party services such as Dropbox, Box &amp; Google Drive via the API. You must download the file content first and then upload it as any other attachment.  The 100MB size limit on attachments in Asana is enforced on this endpoint.  This endpoint expects a multipart/form-data encoded request containing the full contents of the file to be uploaded.  Requests made should follow the HTTP/1.1 specification that line terminators are of the form &#x60;CRLF&#x60; or &#x60;\\r\\n&#x60; outlined [here](http://www.w3.org/Protocols/HTTP/1.1/draft-ietf-http-v11-spec-01#Basic-Rules) in order for the server to reliably and properly handle the request.
-            * @param taskGid The task to operate on. (required)
-            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-        * @return ItemRequest<Attachment>
-        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-        */
-        public ItemRequest<Attachment> createAttachmentForTask(String taskGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-            String path = "/tasks/{task_gid}/attachments".replace("{task_gid}", taskGid);
-
-            ItemRequest<Attachment> req = new ItemRequest<Attachment>(this, Attachment.class, path, "POST")
-                .query("opt_pretty", optPretty)
-                .query("opt_fields", optFields)
-                .query("limit", limit)
-                .query("offset", offset);
-
-            return req;
-        }
-
-        public ItemRequest<Attachment> createAttachmentForTask(String taskGid) throws IOException {
-            return createAttachmentForTask(taskGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-        }
-        /**
         * Delete an attachment
         * Deletes a specific, existing attachment.  Returns an empty data record.
             * @param attachmentGid Globally unique identifier for the attachment. (required)

--- a/src/main/java/com/asana/resources/gen/AttachmentsBase.java
+++ b/src/main/java/com/asana/resources/gen/AttachmentsBase.java
@@ -4,11 +4,13 @@ import com.asana.Client;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
-import com.asana.models.Attachment;
+import com.asana.models.*;
 import java.io.File;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
     public class AttachmentsBase extends Resource {
@@ -17,104 +19,100 @@ import java.util.List;
     */
     public AttachmentsBase(Client client) { super(client); }
 
-            /**
-            * Upload an attachment
-            * Upload an attachment.  This method uploads an attachment to a task and returns the compact record for the created attachment object. It is not possible to attach files from third party services such as Dropbox, Box &amp; Google Drive via the API. You must download the file content first and then upload it as any other attachment.  The 100MB size limit on attachments in Asana is enforced on this endpoint.  This endpoint expects a multipart/form-data encoded request containing the full contents of the file to be uploaded.  Requests made should follow the HTTP/1.1 specification that line terminators are of the form &#x60;CRLF&#x60; or &#x60;\\r\\n&#x60; outlined [here](http://www.w3.org/Protocols/HTTP/1.1/draft-ietf-http-v11-spec-01#Basic-Rules) in order for the server to reliably and properly handle the request.
-                * @param taskGid The task to operate on. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Attachment>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Attachment> createAttachmentForTask(String taskGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}/attachments".replace("{task_gid}", taskGid);
+        /**
+        * Upload an attachment
+        * Upload an attachment.  This method uploads an attachment to a task and returns the compact record for the created attachment object. It is not possible to attach files from third party services such as Dropbox, Box &amp; Google Drive via the API. You must download the file content first and then upload it as any other attachment.  The 100MB size limit on attachments in Asana is enforced on this endpoint.  This endpoint expects a multipart/form-data encoded request containing the full contents of the file to be uploaded.  Requests made should follow the HTTP/1.1 specification that line terminators are of the form &#x60;CRLF&#x60; or &#x60;\\r\\n&#x60; outlined [here](http://www.w3.org/Protocols/HTTP/1.1/draft-ietf-http-v11-spec-01#Basic-Rules) in order for the server to reliably and properly handle the request.
+            * @param taskGid The task to operate on. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Attachment>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Attachment> createAttachmentForTask(String taskGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks/{task_gid}/attachments".replace("{task_gid}", taskGid);
 
-                ItemRequest<Attachment> req = new ItemRequest<Attachment>(this, Attachment.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
+            ItemRequest<Attachment> req = new ItemRequest<Attachment>(this, Attachment.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-                return req;
-            }
+            return req;
+        }
 
-            public ItemRequest<Attachment> createAttachmentForTask(String taskGid) throws IOException {
-                return createAttachmentForTask(taskGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
+        public ItemRequest<Attachment> createAttachmentForTask(String taskGid) throws IOException {
+            return createAttachmentForTask(taskGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Delete an attachment
+        * Deletes a specific, existing attachment.  Returns an empty data record.
+            * @param attachmentGid Globally unique identifier for the attachment. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> deleteAttachment(String attachmentGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/attachments/{attachment_gid}".replace("{attachment_gid}", attachmentGid);
 
-            /**
-            * Delete an attachment
-            * Deletes a specific, existing attachment.  Returns an empty data record.
-                * @param attachmentGid Globally unique identifier for the attachment. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> deleteAttachment(String attachmentGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/attachments/{attachment_gid}".replace("{attachment_gid}", attachmentGid);
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            return req;
+        }
 
-                return req;
-            }
+        public ItemRequest<JsonElement> deleteAttachment(String attachmentGid) throws IOException {
+            return deleteAttachment(attachmentGid, null, false);
+        }
+        /**
+        * Get an attachment
+        * Get the full record for a single attachment.
+            * @param attachmentGid Globally unique identifier for the attachment. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Attachment>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Attachment> getAttachment(String attachmentGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/attachments/{attachment_gid}".replace("{attachment_gid}", attachmentGid);
 
-            public ItemRequest<JsonElement> deleteAttachment(String attachmentGid) throws IOException {
-                return deleteAttachment(attachmentGid, null, false);
-            }
+            ItemRequest<Attachment> req = new ItemRequest<Attachment>(this, Attachment.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-            /**
-            * Get an attachment
-            * Get the full record for a single attachment.
-                * @param attachmentGid Globally unique identifier for the attachment. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Attachment>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Attachment> getAttachment(String attachmentGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/attachments/{attachment_gid}".replace("{attachment_gid}", attachmentGid);
+            return req;
+        }
 
-                ItemRequest<Attachment> req = new ItemRequest<Attachment>(this, Attachment.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+        public ItemRequest<Attachment> getAttachment(String attachmentGid) throws IOException {
+            return getAttachment(attachmentGid, null, false);
+        }
+        /**
+        * Get attachments for a task
+        * Returns the compact records for all attachments on the task.
+            * @param taskGid The task to operate on. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Attachment>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Attachment> getAttachmentsForTask(String taskGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks/{task_gid}/attachments".replace("{task_gid}", taskGid);
 
-                return req;
-            }
+            CollectionRequest<Attachment> req = new CollectionRequest<Attachment>(this, Attachment.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-            public ItemRequest<Attachment> getAttachment(String attachmentGid) throws IOException {
-                return getAttachment(attachmentGid, null, false);
-            }
+            return req;
+        }
 
-            /**
-            * Get attachments for a task
-            * Returns the compact records for all attachments on the task.
-                * @param taskGid The task to operate on. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Attachment>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Attachment> getAttachmentsForTask(String taskGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}/attachments".replace("{task_gid}", taskGid);
-
-                CollectionRequest<Attachment> req = new CollectionRequest<Attachment>(this, Attachment.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
-
-                return req;
-            }
-
-            public CollectionRequest<Attachment> getAttachmentsForTask(String taskGid) throws IOException {
-                return getAttachmentsForTask(taskGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
+        public CollectionRequest<Attachment> getAttachmentsForTask(String taskGid) throws IOException {
+            return getAttachmentsForTask(taskGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
     }

--- a/src/main/java/com/asana/resources/gen/AttachmentsBase.java
+++ b/src/main/java/com/asana/resources/gen/AttachmentsBase.java
@@ -2,44 +2,119 @@ package com.asana.resources.gen;
 
 import com.asana.Client;
 import com.asana.resources.Resource;
-import com.asana.models.Attachment;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
+import com.asana.models.Attachment;
+import java.io.File;
+import com.google.gson.JsonElement;
 
-/**
- * An _attachment_ object represents any file attached to a task in Asana,
- * whether it's an uploaded file or one associated via a third-party service
- * such as Dropbox or Google Drive.
- */
-public class AttachmentsBase extends Resource {
+import java.io.IOException;
+import java.util.List;
+
+    public class AttachmentsBase extends Resource {
     /**
-     * @param client Parent client instance
-     */
-    public AttachmentsBase(Client client) {
-        super(client);
+    * @param client Parent client instance
+    */
+    public AttachmentsBase(Client client) { super(client); }
+
+            /**
+            * Upload an attachment
+            * Upload an attachment.  This method uploads an attachment to a task and returns the compact record for the created attachment object. It is not possible to attach files from third party services such as Dropbox, Box &amp; Google Drive via the API. You must download the file content first and then upload it as any other attachment.  The 100MB size limit on attachments in Asana is enforced on this endpoint.  This endpoint expects a multipart/form-data encoded request containing the full contents of the file to be uploaded.  Requests made should follow the HTTP/1.1 specification that line terminators are of the form &#x60;CRLF&#x60; or &#x60;\\r\\n&#x60; outlined [here](http://www.w3.org/Protocols/HTTP/1.1/draft-ietf-http-v11-spec-01#Basic-Rules) in order for the server to reliably and properly handle the request.
+                * @param taskGid The task to operate on. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Attachment>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Attachment> createAttachmentForTask(String taskGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tasks/{task_gid}/attachments".replace("{task_gid}", taskGid);
+
+                ItemRequest<Attachment> req = new ItemRequest<Attachment>(this, Attachment.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public ItemRequest<Attachment> createAttachmentForTask(String taskGid) throws IOException {
+                return createAttachmentForTask(taskGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Delete an attachment
+            * Deletes a specific, existing attachment.  Returns an empty data record.
+                * @param attachmentGid Globally unique identifier for the attachment. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> deleteAttachment(String attachmentGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/attachments/{attachment_gid}".replace("{attachment_gid}", attachmentGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> deleteAttachment(String attachmentGid) throws IOException {
+                return deleteAttachment(attachmentGid, null, false);
+            }
+
+            /**
+            * Get an attachment
+            * Get the full record for a single attachment.
+                * @param attachmentGid Globally unique identifier for the attachment. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Attachment>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Attachment> getAttachment(String attachmentGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/attachments/{attachment_gid}".replace("{attachment_gid}", attachmentGid);
+
+                ItemRequest<Attachment> req = new ItemRequest<Attachment>(this, Attachment.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<Attachment> getAttachment(String attachmentGid) throws IOException {
+                return getAttachment(attachmentGid, null, false);
+            }
+
+            /**
+            * Get attachments for a task
+            * Returns the compact records for all attachments on the task.
+                * @param taskGid The task to operate on. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Attachment>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Attachment> getAttachmentsForTask(String taskGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tasks/{task_gid}/attachments".replace("{task_gid}", taskGid);
+
+                CollectionRequest<Attachment> req = new CollectionRequest<Attachment>(this, Attachment.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public CollectionRequest<Attachment> getAttachmentsForTask(String taskGid) throws IOException {
+                return getAttachmentsForTask(taskGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
     }
-
-    /**
-     * Returns the full record for a single attachment.
-     *
-     * @param  attachment Globally unique identifier for the attachment.
-     * @return Request object
-     */
-    public ItemRequest<Attachment> findById(String attachment) {
-
-        String path = String.format("/attachments/%s", attachment);
-        return new ItemRequest<Attachment>(this, Attachment.class, path, "GET");
-    }
-
-    /**
-     * Returns the compact records for all attachments on the task.
-     *
-     * @param  task Globally unique identifier for the task.
-     * @return Request object
-     */
-    public CollectionRequest<Attachment> findByTask(String task) {
-
-        String path = String.format("/tasks/%s/attachments", task);
-        return new CollectionRequest<Attachment>(this, Attachment.class, path, "GET");
-    }
-}

--- a/src/main/java/com/asana/resources/gen/BatchApiBase.java
+++ b/src/main/java/com/asana/resources/gen/BatchApiBase.java
@@ -4,39 +4,37 @@ import com.asana.Client;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
-import com.asana.models.Job;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
 import java.util.List;
 
-    public class JobsBase extends Resource {
+    public class BatchApiBase extends Resource {
     /**
     * @param client Parent client instance
     */
-    public JobsBase(Client client) { super(client); }
+    public BatchApiBase(Client client) { super(client); }
 
             /**
-            * Get a job by id
-            * Returns the full record for a job.
-                * @param jobGid Globally unique identifier for the job. (required)
+            * Submit parallel requests
+            * Make multiple requests in parallel to Asana&#x27;s API.
                 * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
                 * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Job>
+            * @return CollectionRequest<JsonElement>
             * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
             */
-            public ItemRequest<Job> getJob(String jobGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/jobs/{job_gid}".replace("{job_gid}", jobGid);
+            public CollectionRequest<JsonElement> createBatchRequest(List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/batch";
 
-                ItemRequest<Job> req = new ItemRequest<Job>(this, Job.class, path, "GET")
+                CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "POST")
                     .query("opt_pretty", optPretty)
                     .query("opt_fields", optFields);
 
                 return req;
             }
 
-            public ItemRequest<Job> getJob(String jobGid) throws IOException {
-                return getJob(jobGid, null, false);
+            public CollectionRequest<JsonElement> createBatchRequest() throws IOException {
+                return createBatchRequest(null, false);
             }
 
     }

--- a/src/main/java/com/asana/resources/gen/BatchApiBase.java
+++ b/src/main/java/com/asana/resources/gen/BatchApiBase.java
@@ -4,9 +4,12 @@ import com.asana.Client;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
+import com.asana.models.*;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
     public class BatchApiBase extends Resource {
@@ -15,26 +18,25 @@ import java.util.List;
     */
     public BatchApiBase(Client client) { super(client); }
 
-            /**
-            * Submit parallel requests
-            * Make multiple requests in parallel to Asana&#x27;s API.
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<JsonElement> createBatchRequest(List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/batch";
+        /**
+        * Submit parallel requests
+        * Make multiple requests in parallel to Asana&#x27;s API.
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<JsonElement> createBatchRequest(List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/batch";
 
-                CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                return req;
-            }
+            return req;
+        }
 
-            public CollectionRequest<JsonElement> createBatchRequest() throws IOException {
-                return createBatchRequest(null, false);
-            }
-
+        public CollectionRequest<JsonElement> createBatchRequest() throws IOException {
+            return createBatchRequest(null, false);
+        }
     }

--- a/src/main/java/com/asana/resources/gen/CustomFieldSettingsBase.java
+++ b/src/main/java/com/asana/resources/gen/CustomFieldSettingsBase.java
@@ -2,46 +2,72 @@ package com.asana.resources.gen;
 
 import com.asana.Client;
 import com.asana.resources.Resource;
-import com.asana.models.CustomFieldSetting;
+import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
+import com.asana.models.CustomFieldSetting;
+import com.google.gson.JsonElement;
 
-/**
- * Custom fields are applied to a particular project or portfolio with the
- * Custom Field Settings resource. This resource both represents the
- * many-to-many join of the Custom Field and Project or Portfolio as well as
- * stores information that is relevant to that particular pairing; for instance,
- * the `is_important` property determines some possible application-specific
- * handling of that custom field and parent.
- */
-public class CustomFieldSettingsBase extends Resource {
+import java.io.IOException;
+import java.util.List;
+
+    public class CustomFieldSettingsBase extends Resource {
     /**
-     * @param client Parent client instance
-     */
-    public CustomFieldSettingsBase(Client client) {
-        super(client);
+    * @param client Parent client instance
+    */
+    public CustomFieldSettingsBase(Client client) { super(client); }
+
+            /**
+            * Get a portfolio&#x27;s custom fields
+            * Returns a list of all of the custom fields settings on a portfolio, in compact form.
+                * @param portfolioGid Globally unique identifier for the portfolio. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<CustomFieldSetting>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<CustomFieldSetting> getCustomFieldSettingsForPortfolio(String portfolioGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/portfolios/{portfolio_gid}/custom_field_settings".replace("{portfolio_gid}", portfolioGid);
+
+                CollectionRequest<CustomFieldSetting> req = new CollectionRequest<CustomFieldSetting>(this, CustomFieldSetting.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public CollectionRequest<CustomFieldSetting> getCustomFieldSettingsForPortfolio(String portfolioGid) throws IOException {
+                return getCustomFieldSettingsForPortfolio(portfolioGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Get a project&#x27;s custom fields
+            * Returns a list of all of the custom fields settings on a project, in compact form. Note that, as in all queries to collections which return compact representation, &#x60;opt_fields&#x60; can be used to include more data than is returned in the compact representation. See the [getting started guide on input/output options](https://developers.asana.com/docs/#input-output-options) for more information.
+                * @param projectGid Globally unique identifier for the project. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<CustomFieldSetting>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<CustomFieldSetting> getCustomFieldSettingsForProject(String projectGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/projects/{project_gid}/custom_field_settings".replace("{project_gid}", projectGid);
+
+                CollectionRequest<CustomFieldSetting> req = new CollectionRequest<CustomFieldSetting>(this, CustomFieldSetting.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public CollectionRequest<CustomFieldSetting> getCustomFieldSettingsForProject(String projectGid) throws IOException {
+                return getCustomFieldSettingsForProject(projectGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
     }
-
-    /**
-     * Returns a list of all of the custom fields settings on a project.
-     *
-     * @param  project The ID of the project for which to list custom field settings
-     * @return Request object
-     */
-    public CollectionRequest<CustomFieldSetting> findByProject(String project) {
-
-        String path = String.format("/projects/%s/custom_field_settings", project);
-        return new CollectionRequest<CustomFieldSetting>(this, CustomFieldSetting.class, path, "GET");
-    }
-
-    /**
-     * Returns a list of all of the custom fields settings on a portfolio.
-     *
-     * @param  portfolio The ID of the portfolio for which to list custom field settings
-     * @return Request object
-     */
-    public CollectionRequest<CustomFieldSetting> findByPortfolio(String portfolio) {
-
-        String path = String.format("/portfolios/%s/custom_field_settings", portfolio);
-        return new CollectionRequest<CustomFieldSetting>(this, CustomFieldSetting.class, path, "GET");
-    }
-}

--- a/src/main/java/com/asana/resources/gen/CustomFieldSettingsBase.java
+++ b/src/main/java/com/asana/resources/gen/CustomFieldSettingsBase.java
@@ -4,10 +4,12 @@ import com.asana.Client;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
-import com.asana.models.CustomFieldSetting;
+import com.asana.models.*;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
     public class CustomFieldSettingsBase extends Resource {
@@ -16,58 +18,56 @@ import java.util.List;
     */
     public CustomFieldSettingsBase(Client client) { super(client); }
 
-            /**
-            * Get a portfolio&#x27;s custom fields
-            * Returns a list of all of the custom fields settings on a portfolio, in compact form.
-                * @param portfolioGid Globally unique identifier for the portfolio. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<CustomFieldSetting>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<CustomFieldSetting> getCustomFieldSettingsForPortfolio(String portfolioGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/portfolios/{portfolio_gid}/custom_field_settings".replace("{portfolio_gid}", portfolioGid);
+        /**
+        * Get a portfolio&#x27;s custom fields
+        * Returns a list of all of the custom fields settings on a portfolio, in compact form.
+            * @param portfolioGid Globally unique identifier for the portfolio. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<CustomFieldSetting>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<CustomFieldSetting> getCustomFieldSettingsForPortfolio(String portfolioGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/portfolios/{portfolio_gid}/custom_field_settings".replace("{portfolio_gid}", portfolioGid);
 
-                CollectionRequest<CustomFieldSetting> req = new CollectionRequest<CustomFieldSetting>(this, CustomFieldSetting.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
+            CollectionRequest<CustomFieldSetting> req = new CollectionRequest<CustomFieldSetting>(this, CustomFieldSetting.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-                return req;
-            }
+            return req;
+        }
 
-            public CollectionRequest<CustomFieldSetting> getCustomFieldSettingsForPortfolio(String portfolioGid) throws IOException {
-                return getCustomFieldSettingsForPortfolio(portfolioGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
+        public CollectionRequest<CustomFieldSetting> getCustomFieldSettingsForPortfolio(String portfolioGid) throws IOException {
+            return getCustomFieldSettingsForPortfolio(portfolioGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Get a project&#x27;s custom fields
+        * Returns a list of all of the custom fields settings on a project, in compact form. Note that, as in all queries to collections which return compact representation, &#x60;opt_fields&#x60; can be used to include more data than is returned in the compact representation. See the [getting started guide on input/output options](https://developers.asana.com/docs/#input-output-options) for more information.
+            * @param projectGid Globally unique identifier for the project. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<CustomFieldSetting>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<CustomFieldSetting> getCustomFieldSettingsForProject(String projectGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/projects/{project_gid}/custom_field_settings".replace("{project_gid}", projectGid);
 
-            /**
-            * Get a project&#x27;s custom fields
-            * Returns a list of all of the custom fields settings on a project, in compact form. Note that, as in all queries to collections which return compact representation, &#x60;opt_fields&#x60; can be used to include more data than is returned in the compact representation. See the [getting started guide on input/output options](https://developers.asana.com/docs/#input-output-options) for more information.
-                * @param projectGid Globally unique identifier for the project. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<CustomFieldSetting>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<CustomFieldSetting> getCustomFieldSettingsForProject(String projectGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/projects/{project_gid}/custom_field_settings".replace("{project_gid}", projectGid);
+            CollectionRequest<CustomFieldSetting> req = new CollectionRequest<CustomFieldSetting>(this, CustomFieldSetting.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-                CollectionRequest<CustomFieldSetting> req = new CollectionRequest<CustomFieldSetting>(this, CustomFieldSetting.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
+            return req;
+        }
 
-                return req;
-            }
-
-            public CollectionRequest<CustomFieldSetting> getCustomFieldSettingsForProject(String projectGid) throws IOException {
-                return getCustomFieldSettingsForProject(projectGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
+        public CollectionRequest<CustomFieldSetting> getCustomFieldSettingsForProject(String projectGid) throws IOException {
+            return getCustomFieldSettingsForProject(projectGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
     }

--- a/src/main/java/com/asana/resources/gen/CustomFieldsBase.java
+++ b/src/main/java/com/asana/resources/gen/CustomFieldsBase.java
@@ -4,10 +4,12 @@ import com.asana.Client;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
-import com.asana.models.CustomField;
+import com.asana.models.*;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
     public class CustomFieldsBase extends Resource {
@@ -16,199 +18,191 @@ import java.util.List;
     */
     public CustomFieldsBase(Client client) { super(client); }
 
-            /**
-            * Create a custom field
-            * Creates a new custom field in a workspace. Every custom field is required to be created in a specific workspace, and this workspace cannot be changed once set.  A custom field’s name must be unique within a workspace and not conflict with names of existing task properties such as ‘Due Date’ or ‘Assignee’. A custom field’s type must be one of ‘text’, ‘enum’, or ‘number’.  Returns the full record of the newly created custom field.
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<CustomField>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<CustomField> createCustomField(String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/custom_fields";
+        /**
+        * Create a custom field
+        * Creates a new custom field in a workspace. Every custom field is required to be created in a specific workspace, and this workspace cannot be changed once set.  A custom field’s name must be unique within a workspace and not conflict with names of existing task properties such as ‘Due Date’ or ‘Assignee’. A custom field’s type must be one of ‘text’, ‘enum’, or ‘number’.  Returns the full record of the newly created custom field.
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<CustomField>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<CustomField> createCustomField(String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/custom_fields";
 
-                ItemRequest<CustomField> req = new ItemRequest<CustomField>(this, CustomField.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
+            ItemRequest<CustomField> req = new ItemRequest<CustomField>(this, CustomField.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-                return req;
-            }
+            return req;
+        }
 
-            public ItemRequest<CustomField> createCustomField() throws IOException {
-                return createCustomField(null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
+        public ItemRequest<CustomField> createCustomField() throws IOException {
+            return createCustomField(null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Create an enum option
+        * Creates an enum option and adds it to this custom field’s list of enum options. A custom field can have at most 50 enum options (including disabled options). By default new enum options are inserted at the end of a custom field’s list. Locked custom fields can only have enum options added by the user who locked the field. Returns the full record of the newly created enum option.
+            * @param customFieldGid Globally unique identifier for the custom field. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> createEnumOptionForCustomField(String customFieldGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/custom_fields/{custom_field_gid}/enum_options".replace("{custom_field_gid}", customFieldGid);
 
-            /**
-            * Create an enum option
-            * Creates an enum option and adds it to this custom field’s list of enum options. A custom field can have at most 50 enum options (including disabled options). By default new enum options are inserted at the end of a custom field’s list. Locked custom fields can only have enum options added by the user who locked the field. Returns the full record of the newly created enum option.
-                * @param customFieldGid Globally unique identifier for the custom field. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> createEnumOptionForCustomField(String customFieldGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/custom_fields/{custom_field_gid}/enum_options".replace("{custom_field_gid}", customFieldGid);
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
+            return req;
+        }
 
-                return req;
-            }
+        public ItemRequest<JsonElement> createEnumOptionForCustomField(String customFieldGid) throws IOException {
+            return createEnumOptionForCustomField(customFieldGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Delete a custom field
+        * A specific, existing custom field can be deleted by making a DELETE request on the URL for that custom field. Locked custom fields can only be deleted by the user who locked the field. Returns an empty data record.
+            * @param customFieldGid Globally unique identifier for the custom field. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> deleteCustomField(String customFieldGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/custom_fields/{custom_field_gid}".replace("{custom_field_gid}", customFieldGid);
 
-            public ItemRequest<JsonElement> createEnumOptionForCustomField(String customFieldGid) throws IOException {
-                return createEnumOptionForCustomField(customFieldGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-            /**
-            * Delete a custom field
-            * A specific, existing custom field can be deleted by making a DELETE request on the URL for that custom field. Locked custom fields can only be deleted by the user who locked the field. Returns an empty data record.
-                * @param customFieldGid Globally unique identifier for the custom field. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> deleteCustomField(String customFieldGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/custom_fields/{custom_field_gid}".replace("{custom_field_gid}", customFieldGid);
+            return req;
+        }
 
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+        public ItemRequest<JsonElement> deleteCustomField(String customFieldGid) throws IOException {
+            return deleteCustomField(customFieldGid, null, false);
+        }
+        /**
+        * Get a custom field
+        * Get the complete definition of a custom field’s metadata.  Since custom fields can be defined for one of a number of types, and these types have different data and behaviors, there are fields that are relevant to a particular type. For instance, as noted above, enum_options is only relevant for the enum type and defines the set of choices that the enum could represent. The examples below show some of these type-specific custom field definitions.
+            * @param customFieldGid Globally unique identifier for the custom field. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<CustomField>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<CustomField> getCustomField(String customFieldGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/custom_fields/{custom_field_gid}".replace("{custom_field_gid}", customFieldGid);
 
-                return req;
-            }
+            ItemRequest<CustomField> req = new ItemRequest<CustomField>(this, CustomField.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-            public ItemRequest<JsonElement> deleteCustomField(String customFieldGid) throws IOException {
-                return deleteCustomField(customFieldGid, null, false);
-            }
+            return req;
+        }
 
-            /**
-            * Get a custom field
-            * Get the complete definition of a custom field’s metadata.  Since custom fields can be defined for one of a number of types, and these types have different data and behaviors, there are fields that are relevant to a particular type. For instance, as noted above, enum_options is only relevant for the enum type and defines the set of choices that the enum could represent. The examples below show some of these type-specific custom field definitions.
-                * @param customFieldGid Globally unique identifier for the custom field. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<CustomField>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<CustomField> getCustomField(String customFieldGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/custom_fields/{custom_field_gid}".replace("{custom_field_gid}", customFieldGid);
+        public ItemRequest<CustomField> getCustomField(String customFieldGid) throws IOException {
+            return getCustomField(customFieldGid, null, false);
+        }
+        /**
+        * Get a workspace&#x27;s custom fields
+        * Returns a list of the compact representation of all of the custom fields in a workspace.
+            * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<CustomField>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<CustomField> getCustomFieldsForWorkspace(String workspaceGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/workspaces/{workspace_gid}/custom_fields".replace("{workspace_gid}", workspaceGid);
 
-                ItemRequest<CustomField> req = new ItemRequest<CustomField>(this, CustomField.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            CollectionRequest<CustomField> req = new CollectionRequest<CustomField>(this, CustomField.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-                return req;
-            }
+            return req;
+        }
 
-            public ItemRequest<CustomField> getCustomField(String customFieldGid) throws IOException {
-                return getCustomField(customFieldGid, null, false);
-            }
+        public CollectionRequest<CustomField> getCustomFieldsForWorkspace(String workspaceGid) throws IOException {
+            return getCustomFieldsForWorkspace(workspaceGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Reorder a custom field&#x27;s enum
+        * Moves a particular enum option to be either before or after another specified enum option in the custom field. Locked custom fields can only be reordered by the user who locked the field.
+            * @param customFieldGid Globally unique identifier for the custom field. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> insertEnumOptionForCustomField(String customFieldGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/custom_fields/{custom_field_gid}/enum_options/insert".replace("{custom_field_gid}", customFieldGid);
 
-            /**
-            * Get a workspace&#x27;s custom fields
-            * Returns a list of the compact representation of all of the custom fields in a workspace.
-                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<CustomField>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<CustomField> getCustomFieldsForWorkspace(String workspaceGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/workspaces/{workspace_gid}/custom_fields".replace("{workspace_gid}", workspaceGid);
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                CollectionRequest<CustomField> req = new CollectionRequest<CustomField>(this, CustomField.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
+            return req;
+        }
 
-                return req;
-            }
+        public ItemRequest<JsonElement> insertEnumOptionForCustomField(String customFieldGid) throws IOException {
+            return insertEnumOptionForCustomField(customFieldGid, null, false);
+        }
+        /**
+        * Update a custom field
+        * A specific, existing custom field can be updated by making a PUT request on the URL for that custom field. Only the fields provided in the &#x60;data&#x60; block will be updated; any unspecified fields will remain unchanged When using this method, it is best to specify only those fields you wish to change, or else you may overwrite changes made by another user since you last retrieved the custom field. A custom field’s &#x60;type&#x60; cannot be updated. An enum custom field’s &#x60;enum_options&#x60; cannot be updated with this endpoint. Instead see “Work With Enum Options” for information on how to update &#x60;enum_options&#x60;. Locked custom fields can only be updated by the user who locked the field. Returns the complete updated custom field record.
+            * @param customFieldGid Globally unique identifier for the custom field. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<CustomField>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<CustomField> updateCustomField(String customFieldGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/custom_fields/{custom_field_gid}".replace("{custom_field_gid}", customFieldGid);
 
-            public CollectionRequest<CustomField> getCustomFieldsForWorkspace(String workspaceGid) throws IOException {
-                return getCustomFieldsForWorkspace(workspaceGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
+            ItemRequest<CustomField> req = new ItemRequest<CustomField>(this, CustomField.class, path, "PUT")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-            /**
-            * Reorder a custom field&#x27;s enum
-            * Moves a particular enum option to be either before or after another specified enum option in the custom field. Locked custom fields can only be reordered by the user who locked the field.
-                * @param customFieldGid Globally unique identifier for the custom field. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> insertEnumOptionForCustomField(String customFieldGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/custom_fields/{custom_field_gid}/enum_options/insert".replace("{custom_field_gid}", customFieldGid);
+            return req;
+        }
 
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+        public ItemRequest<CustomField> updateCustomField(String customFieldGid) throws IOException {
+            return updateCustomField(customFieldGid, null, false);
+        }
+        /**
+        * Update an enum option
+        * Updates an existing enum option. Enum custom fields require at least one enabled enum option. Locked custom fields can only be updated by the user who locked the field. Returns the full record of the updated enum option.
+            * @param enumOptionGid Globally unique identifier for the enum option. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> updateEnumOption(String enumOptionGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/enum_options/{enum_option_gid}".replace("{enum_option_gid}", enumOptionGid);
 
-                return req;
-            }
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "PUT")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-            public ItemRequest<JsonElement> insertEnumOptionForCustomField(String customFieldGid) throws IOException {
-                return insertEnumOptionForCustomField(customFieldGid, null, false);
-            }
+            return req;
+        }
 
-            /**
-            * Update a custom field
-            * A specific, existing custom field can be updated by making a PUT request on the URL for that custom field. Only the fields provided in the &#x60;data&#x60; block will be updated; any unspecified fields will remain unchanged When using this method, it is best to specify only those fields you wish to change, or else you may overwrite changes made by another user since you last retrieved the custom field. A custom field’s &#x60;type&#x60; cannot be updated. An enum custom field’s &#x60;enum_options&#x60; cannot be updated with this endpoint. Instead see “Work With Enum Options” for information on how to update &#x60;enum_options&#x60;. Locked custom fields can only be updated by the user who locked the field. Returns the complete updated custom field record.
-                * @param customFieldGid Globally unique identifier for the custom field. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<CustomField>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<CustomField> updateCustomField(String customFieldGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/custom_fields/{custom_field_gid}".replace("{custom_field_gid}", customFieldGid);
-
-                ItemRequest<CustomField> req = new ItemRequest<CustomField>(this, CustomField.class, path, "PUT")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<CustomField> updateCustomField(String customFieldGid) throws IOException {
-                return updateCustomField(customFieldGid, null, false);
-            }
-
-            /**
-            * Update an enum option
-            * Updates an existing enum option. Enum custom fields require at least one enabled enum option. Locked custom fields can only be updated by the user who locked the field. Returns the full record of the updated enum option.
-                * @param enumOptionGid Globally unique identifier for the enum option. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> updateEnumOption(String enumOptionGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/enum_options/{enum_option_gid}".replace("{enum_option_gid}", enumOptionGid);
-
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "PUT")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<JsonElement> updateEnumOption(String enumOptionGid) throws IOException {
-                return updateEnumOption(enumOptionGid, null, false);
-            }
-
+        public ItemRequest<JsonElement> updateEnumOption(String enumOptionGid) throws IOException {
+            return updateEnumOption(enumOptionGid, null, false);
+        }
     }

--- a/src/main/java/com/asana/resources/gen/CustomFieldsBase.java
+++ b/src/main/java/com/asana/resources/gen/CustomFieldsBase.java
@@ -2,147 +2,213 @@ package com.asana.resources.gen;
 
 import com.asana.Client;
 import com.asana.resources.Resource;
-import com.asana.models.CustomField;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
+import com.asana.models.CustomField;
+import com.google.gson.JsonElement;
 
-/**
- * Custom Fields store the metadata that is used in order to add user-specified
- * information to tasks in Asana. Be sure to reference the [Custom
- * Fields](/developers/documentation/getting-started/custom-fields) developer
- * documentation for more information about how custom fields relate to various
- * resources in Asana.
- *
- * Users in Asana can [lock custom
- * fields](/guide/help/premium/custom-fields#gl-lock-fields), which will make
- * them read-only when accessed by other users. Attempting to edit a locked
- * custom field will return HTTP error code `403 Forbidden`.
- */
-public class CustomFieldsBase extends Resource {
+import java.io.IOException;
+import java.util.List;
+
+    public class CustomFieldsBase extends Resource {
     /**
-     * @param client Parent client instance
-     */
-    public CustomFieldsBase(Client client) {
-        super(client);
+    * @param client Parent client instance
+    */
+    public CustomFieldsBase(Client client) { super(client); }
+
+            /**
+            * Create a custom field
+            * Creates a new custom field in a workspace. Every custom field is required to be created in a specific workspace, and this workspace cannot be changed once set.  A custom field’s name must be unique within a workspace and not conflict with names of existing task properties such as ‘Due Date’ or ‘Assignee’. A custom field’s type must be one of ‘text’, ‘enum’, or ‘number’.  Returns the full record of the newly created custom field.
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<CustomField>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<CustomField> createCustomField(String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/custom_fields";
+
+                ItemRequest<CustomField> req = new ItemRequest<CustomField>(this, CustomField.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public ItemRequest<CustomField> createCustomField() throws IOException {
+                return createCustomField(null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Create an enum option
+            * Creates an enum option and adds it to this custom field’s list of enum options. A custom field can have at most 50 enum options (including disabled options). By default new enum options are inserted at the end of a custom field’s list. Locked custom fields can only have enum options added by the user who locked the field. Returns the full record of the newly created enum option.
+                * @param customFieldGid Globally unique identifier for the custom field. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> createEnumOptionForCustomField(String customFieldGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/custom_fields/{custom_field_gid}/enum_options".replace("{custom_field_gid}", customFieldGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> createEnumOptionForCustomField(String customFieldGid) throws IOException {
+                return createEnumOptionForCustomField(customFieldGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Delete a custom field
+            * A specific, existing custom field can be deleted by making a DELETE request on the URL for that custom field. Locked custom fields can only be deleted by the user who locked the field. Returns an empty data record.
+                * @param customFieldGid Globally unique identifier for the custom field. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> deleteCustomField(String customFieldGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/custom_fields/{custom_field_gid}".replace("{custom_field_gid}", customFieldGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> deleteCustomField(String customFieldGid) throws IOException {
+                return deleteCustomField(customFieldGid, null, false);
+            }
+
+            /**
+            * Get a custom field
+            * Get the complete definition of a custom field’s metadata.  Since custom fields can be defined for one of a number of types, and these types have different data and behaviors, there are fields that are relevant to a particular type. For instance, as noted above, enum_options is only relevant for the enum type and defines the set of choices that the enum could represent. The examples below show some of these type-specific custom field definitions.
+                * @param customFieldGid Globally unique identifier for the custom field. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<CustomField>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<CustomField> getCustomField(String customFieldGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/custom_fields/{custom_field_gid}".replace("{custom_field_gid}", customFieldGid);
+
+                ItemRequest<CustomField> req = new ItemRequest<CustomField>(this, CustomField.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<CustomField> getCustomField(String customFieldGid) throws IOException {
+                return getCustomField(customFieldGid, null, false);
+            }
+
+            /**
+            * Get a workspace&#x27;s custom fields
+            * Returns a list of the compact representation of all of the custom fields in a workspace.
+                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<CustomField>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<CustomField> getCustomFieldsForWorkspace(String workspaceGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/workspaces/{workspace_gid}/custom_fields".replace("{workspace_gid}", workspaceGid);
+
+                CollectionRequest<CustomField> req = new CollectionRequest<CustomField>(this, CustomField.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public CollectionRequest<CustomField> getCustomFieldsForWorkspace(String workspaceGid) throws IOException {
+                return getCustomFieldsForWorkspace(workspaceGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Reorder a custom field&#x27;s enum
+            * Moves a particular enum option to be either before or after another specified enum option in the custom field. Locked custom fields can only be reordered by the user who locked the field.
+                * @param customFieldGid Globally unique identifier for the custom field. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> insertEnumOptionForCustomField(String customFieldGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/custom_fields/{custom_field_gid}/enum_options/insert".replace("{custom_field_gid}", customFieldGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> insertEnumOptionForCustomField(String customFieldGid) throws IOException {
+                return insertEnumOptionForCustomField(customFieldGid, null, false);
+            }
+
+            /**
+            * Update a custom field
+            * A specific, existing custom field can be updated by making a PUT request on the URL for that custom field. Only the fields provided in the &#x60;data&#x60; block will be updated; any unspecified fields will remain unchanged When using this method, it is best to specify only those fields you wish to change, or else you may overwrite changes made by another user since you last retrieved the custom field. A custom field’s &#x60;type&#x60; cannot be updated. An enum custom field’s &#x60;enum_options&#x60; cannot be updated with this endpoint. Instead see “Work With Enum Options” for information on how to update &#x60;enum_options&#x60;. Locked custom fields can only be updated by the user who locked the field. Returns the complete updated custom field record.
+                * @param customFieldGid Globally unique identifier for the custom field. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<CustomField>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<CustomField> updateCustomField(String customFieldGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/custom_fields/{custom_field_gid}".replace("{custom_field_gid}", customFieldGid);
+
+                ItemRequest<CustomField> req = new ItemRequest<CustomField>(this, CustomField.class, path, "PUT")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<CustomField> updateCustomField(String customFieldGid) throws IOException {
+                return updateCustomField(customFieldGid, null, false);
+            }
+
+            /**
+            * Update an enum option
+            * Updates an existing enum option. Enum custom fields require at least one enabled enum option. Locked custom fields can only be updated by the user who locked the field. Returns the full record of the updated enum option.
+                * @param enumOptionGid Globally unique identifier for the enum option. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> updateEnumOption(String enumOptionGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/enum_options/{enum_option_gid}".replace("{enum_option_gid}", enumOptionGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "PUT")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> updateEnumOption(String enumOptionGid) throws IOException {
+                return updateEnumOption(enumOptionGid, null, false);
+            }
+
     }
-
-    /**
-     * Creates a new custom field in a workspace. Every custom field is required to be created in a specific workspace, and this workspace cannot be changed once set.
-     *
-     * A custom field's `name` must be unique within a workspace and not conflict with names of existing task properties such as 'Due Date' or 'Assignee'. A custom field's `type` must be one of  'text', 'enum', or 'number'.
-     *
-     * Returns the full record of the newly created custom field.
-     *
-     * @return Request object
-     */
-    public ItemRequest<CustomField> create() {
-
-        return new ItemRequest<CustomField>(this, CustomField.class, "/custom_fields", "POST");
-    }
-
-    /**
-     * Returns the complete definition of a custom field's metadata.
-     *
-     * @param  customField Globally unique identifier for the custom field.
-     * @return Request object
-     */
-    public ItemRequest<CustomField> findById(String customField) {
-
-        String path = String.format("/custom_fields/%s", customField);
-        return new ItemRequest<CustomField>(this, CustomField.class, path, "GET");
-    }
-
-    /**
-     * Returns a list of the compact representation of all of the custom fields in a workspace.
-     *
-     * @param  workspace The workspace or organization to find custom field definitions in.
-     * @return Request object
-     */
-    public CollectionRequest<CustomField> findByWorkspace(String workspace) {
-
-        String path = String.format("/workspaces/%s/custom_fields", workspace);
-        return new CollectionRequest<CustomField>(this, CustomField.class, path, "GET");
-    }
-
-    /**
-     * A specific, existing custom field can be updated by making a PUT request on the URL for that custom field. Only the fields provided in the `data` block will be updated; any unspecified fields will remain unchanged
-     *
-     * When using this method, it is best to specify only those fields you wish to change, or else you may overwrite changes made by another user since you last retrieved the custom field.
-     *
-     * An enum custom field's `enum_options` cannot be updated with this endpoint. Instead see "Work With Enum Options" for information on how to update `enum_options`.
-     *
-     * Locked custom fields can only be updated by the user who locked the field.
-     *
-     * Returns the complete updated custom field record.
-     *
-     * @param  customField Globally unique identifier for the custom field.
-     * @return Request object
-     */
-    public ItemRequest<CustomField> update(String customField) {
-
-        String path = String.format("/custom_fields/%s", customField);
-        return new ItemRequest<CustomField>(this, CustomField.class, path, "PUT");
-    }
-
-    /**
-     * A specific, existing custom field can be deleted by making a DELETE request on the URL for that custom field.
-     *
-     * Locked custom fields can only be deleted by the user who locked the field.
-     *
-     * Returns an empty data record.
-     *
-     * @param  customField Globally unique identifier for the custom field.
-     * @return Request object
-     */
-    public ItemRequest<CustomField> delete(String customField) {
-
-        String path = String.format("/custom_fields/%s", customField);
-        return new ItemRequest<CustomField>(this, CustomField.class, path, "DELETE");
-    }
-
-    /**
-     * Creates an enum option and adds it to this custom field's list of enum options. A custom field can have at most 50 enum options (including disabled options). By default new enum options are inserted at the end of a custom field's list.
-     *
-     * Locked custom fields can only have enum options added by the user who locked the field.
-     *
-     * Returns the full record of the newly created enum option.
-     *
-     * @param  customField Globally unique identifier for the custom field.
-     * @return Request object
-     */
-    public ItemRequest<CustomField> createEnumOption(String customField) {
-
-        String path = String.format("/custom_fields/%s/enum_options", customField);
-        return new ItemRequest<CustomField>(this, CustomField.class, path, "POST");
-    }
-
-    /**
-     * Updates an existing enum option. Enum custom fields require at least one enabled enum option.
-     *
-     * Locked custom fields can only be updated by the user who locked the field.
-     *
-     * Returns the full record of the updated enum option.
-     *
-     * @param  enumOption Globally unique identifier for the enum option.
-     * @return Request object
-     */
-    public ItemRequest<CustomField> updateEnumOption(String enumOption) {
-
-        String path = String.format("/enum_options/%s", enumOption);
-        return new ItemRequest<CustomField>(this, CustomField.class, path, "PUT");
-    }
-
-    /**
-     * Moves a particular enum option to be either before or after another specified enum option in the custom field.
-     *
-     * Locked custom fields can only be reordered by the user who locked the field.
-     *
-     * @param  customField Globally unique identifier for the custom field.
-     * @return Request object
-     */
-    public ItemRequest<CustomField> insertEnumOption(String customField) {
-
-        String path = String.format("/custom_fields/%s/enum_options/insert", customField);
-        return new ItemRequest<CustomField>(this, CustomField.class, path, "POST");
-    }
-}

--- a/src/main/java/com/asana/resources/gen/EventsBase.java
+++ b/src/main/java/com/asana/resources/gen/EventsBase.java
@@ -2,39 +2,43 @@ package com.asana.resources.gen;
 
 import com.asana.Client;
 import com.asana.resources.Resource;
+import com.asana.requests.ItemRequest;
+import com.asana.requests.CollectionRequest;
+import com.google.gson.JsonElement;
 
-/**
- * An _event_ is an object representing a change to a resource that was observed
- * by an event subscription.
- * 
- * In general, requesting events on a resource is faster and subject to higher
- * rate limits than requesting the resource itself. Additionally, change events
- * bubble up - listening to events on a project would include when stories are
- * added to tasks in the project, even on subtasks.
- * 
- * Establish an initial sync token by making a request with no sync token.
- * The response will be a `412` error - the same as if the sync token had
- * expired.
- * 
- * Subsequent requests should always provide the sync token from the immediately
- * preceding call.
- * 
- * Sync tokens may not be valid if you attempt to go 'backward' in the history
- * by requesting previous tokens, though re-requesting the current sync token
- * is generally safe, and will always return the same results.
- * 
- * When you receive a `412 Precondition Failed` error, it means that the
- * sync token is either invalid or expired. If you are attempting to keep a set
- * of data in sync, this signals you may need to re-crawl the data.
- * 
- * Sync tokens always expire after 24 hours, but may expire sooner, depending on
- * load on the service.
- */
-public class EventsBase extends Resource {
+import java.io.IOException;
+import java.util.List;
+
+    public class EventsBase extends Resource {
     /**
-     * @param client Parent client instance
-     */
-    public EventsBase(Client client) {
-        super(client);
+    * @param client Parent client instance
+    */
+    public EventsBase(Client client) { super(client); }
+
+            /**
+            * Get events on a resource
+            * Returns the full record for all events that have occurred since the sync token was created.  A GET request to the endpoint /[path_to_resource]/events can be made in lieu of including the resource ID in the data for the request.  *Note: The resource returned will be the resource that triggered the event. This may be different from the one that the events were requested for. For example, a subscription to a project will contain events for tasks contained within the project.*
+                * @param sync A sync token received from the last request, or none on first sync. Events will be returned from the point in time that the sync token was generated. *Note: On your first request, omit the sync token. The response will be the same as for an expired sync token, and will include a new valid sync token.If the sync token is too old (which may happen from time to time) the API will return a &#x60;412 Precondition Failed&#x60; error, and include a fresh sync token in the response.* (optional)
+                * @param resource A resource ID to subscribe to. The resource can be a task or project. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<JsonElement> getEvents(String sync, String resource, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/events";
+
+                CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "GET")
+                    .query("resource", resource)
+                    .query("sync", sync)
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public CollectionRequest<JsonElement> getEvents(String sync, String resource) throws IOException {
+                return getEvents(sync, resource, null, false);
+            }
+
     }
-}

--- a/src/main/java/com/asana/resources/gen/EventsBase.java
+++ b/src/main/java/com/asana/resources/gen/EventsBase.java
@@ -4,9 +4,12 @@ import com.asana.Client;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
+import com.asana.models.*;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
     public class EventsBase extends Resource {
@@ -15,30 +18,29 @@ import java.util.List;
     */
     public EventsBase(Client client) { super(client); }
 
-            /**
-            * Get events on a resource
-            * Returns the full record for all events that have occurred since the sync token was created.  A GET request to the endpoint /[path_to_resource]/events can be made in lieu of including the resource ID in the data for the request.  *Note: The resource returned will be the resource that triggered the event. This may be different from the one that the events were requested for. For example, a subscription to a project will contain events for tasks contained within the project.*
-                * @param sync A sync token received from the last request, or none on first sync. Events will be returned from the point in time that the sync token was generated. *Note: On your first request, omit the sync token. The response will be the same as for an expired sync token, and will include a new valid sync token.If the sync token is too old (which may happen from time to time) the API will return a &#x60;412 Precondition Failed&#x60; error, and include a fresh sync token in the response.* (optional)
-                * @param resource A resource ID to subscribe to. The resource can be a task or project. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<JsonElement> getEvents(String sync, String resource, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/events";
+        /**
+        * Get events on a resource
+        * Returns the full record for all events that have occurred since the sync token was created.  A GET request to the endpoint /[path_to_resource]/events can be made in lieu of including the resource ID in the data for the request.  *Note: The resource returned will be the resource that triggered the event. This may be different from the one that the events were requested for. For example, a subscription to a project will contain events for tasks contained within the project.*
+            * @param sync A sync token received from the last request, or none on first sync. Events will be returned from the point in time that the sync token was generated. *Note: On your first request, omit the sync token. The response will be the same as for an expired sync token, and will include a new valid sync token.If the sync token is too old (which may happen from time to time) the API will return a &#x60;412 Precondition Failed&#x60; error, and include a fresh sync token in the response.* (optional)
+            * @param resource A resource ID to subscribe to. The resource can be a task or project. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<JsonElement> getEvents(String sync, String resource, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/events";
 
-                CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "GET")
-                    .query("resource", resource)
-                    .query("sync", sync)
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "GET")
+                .query("resource", resource)
+                .query("sync", sync)
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                return req;
-            }
+            return req;
+        }
 
-            public CollectionRequest<JsonElement> getEvents(String sync, String resource) throws IOException {
-                return getEvents(sync, resource, null, false);
-            }
-
+        public CollectionRequest<JsonElement> getEvents(String sync, String resource) throws IOException {
+            return getEvents(sync, resource, null, false);
+        }
     }

--- a/src/main/java/com/asana/resources/gen/JobsBase.java
+++ b/src/main/java/com/asana/resources/gen/JobsBase.java
@@ -4,10 +4,12 @@ import com.asana.Client;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
-import com.asana.models.Job;
+import com.asana.models.*;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
     public class JobsBase extends Resource {
@@ -16,27 +18,26 @@ import java.util.List;
     */
     public JobsBase(Client client) { super(client); }
 
-            /**
-            * Get a job by id
-            * Returns the full record for a job.
-                * @param jobGid Globally unique identifier for the job. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Job>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Job> getJob(String jobGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/jobs/{job_gid}".replace("{job_gid}", jobGid);
+        /**
+        * Get a job by id
+        * Returns the full record for a job.
+            * @param jobGid Globally unique identifier for the job. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Job>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Job> getJob(String jobGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/jobs/{job_gid}".replace("{job_gid}", jobGid);
 
-                ItemRequest<Job> req = new ItemRequest<Job>(this, Job.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            ItemRequest<Job> req = new ItemRequest<Job>(this, Job.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                return req;
-            }
+            return req;
+        }
 
-            public ItemRequest<Job> getJob(String jobGid) throws IOException {
-                return getJob(jobGid, null, false);
-            }
-
+        public ItemRequest<Job> getJob(String jobGid) throws IOException {
+            return getJob(jobGid, null, false);
+        }
     }

--- a/src/main/java/com/asana/resources/gen/OrganizationExportsBase.java
+++ b/src/main/java/com/asana/resources/gen/OrganizationExportsBase.java
@@ -4,10 +4,12 @@ import com.asana.Client;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
-import com.asana.models.OrganizationExport;
+import com.asana.models.*;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
     public class OrganizationExportsBase extends Resource {
@@ -16,53 +18,51 @@ import java.util.List;
     */
     public OrganizationExportsBase(Client client) { super(client); }
 
-            /**
-            * Create an organization export request
-            * This method creates a request to export an Organization. Asana will complete the export at some point after you create the request.
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<OrganizationExport>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<OrganizationExport> createOrganizationExport(String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/organization_exports";
+        /**
+        * Create an organization export request
+        * This method creates a request to export an Organization. Asana will complete the export at some point after you create the request.
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<OrganizationExport>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<OrganizationExport> createOrganizationExport(String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/organization_exports";
 
-                ItemRequest<OrganizationExport> req = new ItemRequest<OrganizationExport>(this, OrganizationExport.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
+            ItemRequest<OrganizationExport> req = new ItemRequest<OrganizationExport>(this, OrganizationExport.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-                return req;
-            }
+            return req;
+        }
 
-            public ItemRequest<OrganizationExport> createOrganizationExport() throws IOException {
-                return createOrganizationExport(null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
+        public ItemRequest<OrganizationExport> createOrganizationExport() throws IOException {
+            return createOrganizationExport(null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Get details on an org export request
+        * Returns details of a previously-requested Organization export.
+            * @param organizationExportGid Globally unique identifier for the organization export. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<OrganizationExport>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<OrganizationExport> getOrganizationExport(String organizationExportGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/organization_exports/{organization_export_gid}".replace("{organization_export_gid}", organizationExportGid);
 
-            /**
-            * Get details on an org export request
-            * Returns details of a previously-requested Organization export.
-                * @param organizationExportGid Globally unique identifier for the organization export. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<OrganizationExport>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<OrganizationExport> getOrganizationExport(String organizationExportGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/organization_exports/{organization_export_gid}".replace("{organization_export_gid}", organizationExportGid);
+            ItemRequest<OrganizationExport> req = new ItemRequest<OrganizationExport>(this, OrganizationExport.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                ItemRequest<OrganizationExport> req = new ItemRequest<OrganizationExport>(this, OrganizationExport.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            return req;
+        }
 
-                return req;
-            }
-
-            public ItemRequest<OrganizationExport> getOrganizationExport(String organizationExportGid) throws IOException {
-                return getOrganizationExport(organizationExportGid, null, false);
-            }
-
+        public ItemRequest<OrganizationExport> getOrganizationExport(String organizationExportGid) throws IOException {
+            return getOrganizationExport(organizationExportGid, null, false);
+        }
     }

--- a/src/main/java/com/asana/resources/gen/OrganizationExportsBase.java
+++ b/src/main/java/com/asana/resources/gen/OrganizationExportsBase.java
@@ -2,52 +2,67 @@ package com.asana.resources.gen;
 
 import com.asana.Client;
 import com.asana.resources.Resource;
-import com.asana.models.OrganizationExport;
 import com.asana.requests.ItemRequest;
+import com.asana.requests.CollectionRequest;
+import com.asana.models.OrganizationExport;
+import com.google.gson.JsonElement;
 
-/**
- * An _organization_export_ object represents a request to export the complete data of an Organization
- * in JSON format.
- *
- * To export an Organization using this API:
- *
- * * Create an `organization_export` [request](#create) and store the id that is returned.\
- * * Request the `organization_export` every few minutes, until the `state` field contains 'finished'.\
- * * Download the file located at the URL in the `download_url` field.
- *
- * Exports can take a long time, from several minutes to a few hours for large Organizations.
- *
- * **Note:** These endpoints are only available to [Service Accounts](/guide/help/premium/service-accounts)
- * of an [Enterprise](/enterprise) Organization.
- */
-public class OrganizationExportsBase extends Resource {
+import java.io.IOException;
+import java.util.List;
+
+    public class OrganizationExportsBase extends Resource {
     /**
-     * @param client Parent client instance
-     */
-    public OrganizationExportsBase(Client client) {
-        super(client);
+    * @param client Parent client instance
+    */
+    public OrganizationExportsBase(Client client) { super(client); }
+
+            /**
+            * Create an organization export request
+            * This method creates a request to export an Organization. Asana will complete the export at some point after you create the request.
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<OrganizationExport>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<OrganizationExport> createOrganizationExport(String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/organization_exports";
+
+                ItemRequest<OrganizationExport> req = new ItemRequest<OrganizationExport>(this, OrganizationExport.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public ItemRequest<OrganizationExport> createOrganizationExport() throws IOException {
+                return createOrganizationExport(null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Get details on an org export request
+            * Returns details of a previously-requested Organization export.
+                * @param organizationExportGid Globally unique identifier for the organization export. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<OrganizationExport>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<OrganizationExport> getOrganizationExport(String organizationExportGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/organization_exports/{organization_export_gid}".replace("{organization_export_gid}", organizationExportGid);
+
+                ItemRequest<OrganizationExport> req = new ItemRequest<OrganizationExport>(this, OrganizationExport.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<OrganizationExport> getOrganizationExport(String organizationExportGid) throws IOException {
+                return getOrganizationExport(organizationExportGid, null, false);
+            }
+
     }
-
-    /**
-     * Returns details of a previously-requested Organization export.
-     *
-     * @param  organizationExport Globally unique identifier for the Organization export.
-     * @return Request object
-     */
-    public ItemRequest<OrganizationExport> findById(String organizationExport) {
-
-        String path = String.format("/organization_exports/%s", organizationExport);
-        return new ItemRequest<OrganizationExport>(this, OrganizationExport.class, path, "GET");
-    }
-
-    /**
-     * This method creates a request to export an Organization. Asana will complete the export at some
-     * point after you create the request.
-     *
-     * @return Request object
-     */
-    public ItemRequest<OrganizationExport> create() {
-
-        return new ItemRequest<OrganizationExport>(this, OrganizationExport.class, "/organization_exports", "POST");
-    }
-}

--- a/src/main/java/com/asana/resources/gen/PortfolioMembershipsBase.java
+++ b/src/main/java/com/asana/resources/gen/PortfolioMembershipsBase.java
@@ -4,10 +4,12 @@ import com.asana.Client;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
-import com.asana.models.PortfolioMembership;
+import com.asana.models.*;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
     public class PortfolioMembershipsBase extends Resource {
@@ -16,88 +18,85 @@ import java.util.List;
     */
     public PortfolioMembershipsBase(Client client) { super(client); }
 
-            /**
-            * Get a portfolio membership
-            * Returns the complete portfolio record for a single portfolio membership.
-                * @param portfolioMembershipGid  (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<PortfolioMembership>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<PortfolioMembership> getPortfolioMembership(String portfolioMembershipGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/portfolio_memberships/{portfolio_membership_gid}".replace("{portfolio_membership_gid}", portfolioMembershipGid);
+        /**
+        * Get a portfolio membership
+        * Returns the complete portfolio record for a single portfolio membership.
+            * @param portfolioMembershipGid  (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<PortfolioMembership>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<PortfolioMembership> getPortfolioMembership(String portfolioMembershipGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/portfolio_memberships/{portfolio_membership_gid}".replace("{portfolio_membership_gid}", portfolioMembershipGid);
 
-                ItemRequest<PortfolioMembership> req = new ItemRequest<PortfolioMembership>(this, PortfolioMembership.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            ItemRequest<PortfolioMembership> req = new ItemRequest<PortfolioMembership>(this, PortfolioMembership.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                return req;
-            }
+            return req;
+        }
 
-            public ItemRequest<PortfolioMembership> getPortfolioMembership(String portfolioMembershipGid) throws IOException {
-                return getPortfolioMembership(portfolioMembershipGid, null, false);
-            }
+        public ItemRequest<PortfolioMembership> getPortfolioMembership(String portfolioMembershipGid) throws IOException {
+            return getPortfolioMembership(portfolioMembershipGid, null, false);
+        }
+        /**
+        * Get multiple portfolio memberships
+        * Returns a list of portfolio memberships in compact representation. You must specify &#x60;portfolio&#x60;, &#x60;portfolio&#x60; and &#x60;user&#x60;, or &#x60;workspace&#x60; and &#x60;user&#x60;.
+            * @param user The user to filter results on. (optional)
+            * @param workspace The workspace to filter results on. (optional)
+            * @param portfolio The portfolio to filter results on. (optional)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<PortfolioMembership>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<PortfolioMembership> getPortfolioMemberships(String user, String workspace, String portfolio, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/portfolio_memberships";
 
-            /**
-            * Get multiple portfolio memberships
-            * Returns a list of portfolio memberships in compact representation. You must specify &#x60;portfolio&#x60;, &#x60;portfolio&#x60; and &#x60;user&#x60;, or &#x60;workspace&#x60; and &#x60;user&#x60;.
-                * @param user The user to filter results on. (optional)
-                * @param workspace The workspace to filter results on. (optional)
-                * @param portfolio The portfolio to filter results on. (optional)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<PortfolioMembership>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<PortfolioMembership> getPortfolioMemberships(String user, String workspace, String portfolio, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/portfolio_memberships";
+            CollectionRequest<PortfolioMembership> req = new CollectionRequest<PortfolioMembership>(this, PortfolioMembership.class, path, "GET")
+                .query("portfolio", portfolio)
+                .query("workspace", workspace)
+                .query("user", user)
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-                CollectionRequest<PortfolioMembership> req = new CollectionRequest<PortfolioMembership>(this, PortfolioMembership.class, path, "GET")
-                    .query("portfolio", portfolio)
-                    .query("workspace", workspace)
-                    .query("user", user)
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
+            return req;
+        }
 
-                return req;
-            }
+        public CollectionRequest<PortfolioMembership> getPortfolioMemberships(String user, String workspace, String portfolio) throws IOException {
+            return getPortfolioMemberships(user, workspace, portfolio, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Get memberships from a portfolio
+        * Returns the compact portfolio membership records for the portfolio.
+            * @param portfolioGid Globally unique identifier for the portfolio. (required)
+            * @param user The user to filter results on. (optional)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<PortfolioMembership>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<PortfolioMembership> getPortfolioMembershipsForPortfolio(String portfolioGid, String user, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/portfolios/{portfolio_gid}/portfolio_memberships".replace("{portfolio_gid}", portfolioGid);
 
-            public CollectionRequest<PortfolioMembership> getPortfolioMemberships(String user, String workspace, String portfolio) throws IOException {
-                return getPortfolioMemberships(user, workspace, portfolio, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
+            CollectionRequest<PortfolioMembership> req = new CollectionRequest<PortfolioMembership>(this, PortfolioMembership.class, path, "GET")
+                .query("user", user)
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-            /**
-            * Get memberships from a portfolio
-            * Returns the compact portfolio membership records for the portfolio.
-                * @param portfolioGid Globally unique identifier for the portfolio. (required)
-                * @param user The user to filter results on. (optional)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<PortfolioMembership>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<PortfolioMembership> getPortfolioMembershipsForPortfolio(String portfolioGid, String user, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/portfolios/{portfolio_gid}/portfolio_memberships".replace("{portfolio_gid}", portfolioGid);
+            return req;
+        }
 
-                CollectionRequest<PortfolioMembership> req = new CollectionRequest<PortfolioMembership>(this, PortfolioMembership.class, path, "GET")
-                    .query("user", user)
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
-
-                return req;
-            }
-
-            public CollectionRequest<PortfolioMembership> getPortfolioMembershipsForPortfolio(String portfolioGid, String user) throws IOException {
-                return getPortfolioMembershipsForPortfolio(portfolioGid, user, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
+        public CollectionRequest<PortfolioMembership> getPortfolioMembershipsForPortfolio(String portfolioGid, String user) throws IOException {
+            return getPortfolioMembershipsForPortfolio(portfolioGid, user, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
     }

--- a/src/main/java/com/asana/resources/gen/PortfolioMembershipsBase.java
+++ b/src/main/java/com/asana/resources/gen/PortfolioMembershipsBase.java
@@ -43,7 +43,7 @@ import java.util.List;
         /**
         * Get multiple portfolio memberships
         * Returns a list of portfolio memberships in compact representation. You must specify &#x60;portfolio&#x60;, &#x60;portfolio&#x60; and &#x60;user&#x60;, or &#x60;workspace&#x60; and &#x60;user&#x60;.
-            * @param user The user to filter results on. (optional)
+            * @param user A string identifying a user. This can either be the string \&quot;me\&quot;, an email, or the gid of a user. (optional)
             * @param workspace The workspace to filter results on. (optional)
             * @param portfolio The portfolio to filter results on. (optional)
             * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
@@ -75,7 +75,7 @@ import java.util.List;
         * Get memberships from a portfolio
         * Returns the compact portfolio membership records for the portfolio.
             * @param portfolioGid Globally unique identifier for the portfolio. (required)
-            * @param user The user to filter results on. (optional)
+            * @param user A string identifying a user. This can either be the string \&quot;me\&quot;, an email, or the gid of a user. (optional)
             * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
             * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
             * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)

--- a/src/main/java/com/asana/resources/gen/PortfoliosBase.java
+++ b/src/main/java/com/asana/resources/gen/PortfoliosBase.java
@@ -4,10 +4,12 @@ import com.asana.Client;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
-import com.asana.models.Portfolio;
+import com.asana.models.*;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
     public class PortfoliosBase extends Resource {
@@ -16,286 +18,274 @@ import java.util.List;
     */
     public PortfoliosBase(Client client) { super(client); }
 
-            /**
-            * Add a custom field to a portfolio
-            * Custom fields are associated with portfolios by way of custom field settings.  This method creates a setting for the portfolio.
-                * @param portfolioGid Globally unique identifier for the portfolio. (required)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> addCustomFieldSettingForPortfolio(String portfolioGid, Boolean optPretty) throws IOException {
-                String path = "/portfolios/{portfolio_gid}/addCustomFieldSetting".replace("{portfolio_gid}", portfolioGid);
+        /**
+        * Add a custom field to a portfolio
+        * Custom fields are associated with portfolios by way of custom field settings.  This method creates a setting for the portfolio.
+            * @param portfolioGid Globally unique identifier for the portfolio. (required)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> addCustomFieldSettingForPortfolio(String portfolioGid, Boolean optPretty) throws IOException {
+            String path = "/portfolios/{portfolio_gid}/addCustomFieldSetting".replace("{portfolio_gid}", portfolioGid);
 
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
-                    .query("opt_pretty", optPretty);
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                .query("opt_pretty", optPretty);
 
-                return req;
-            }
+            return req;
+        }
 
-            public ItemRequest<JsonElement> addCustomFieldSettingForPortfolio(String portfolioGid) throws IOException {
-                return addCustomFieldSettingForPortfolio(portfolioGid, false);
-            }
+        public ItemRequest<JsonElement> addCustomFieldSettingForPortfolio(String portfolioGid) throws IOException {
+            return addCustomFieldSettingForPortfolio(portfolioGid, false);
+        }
+        /**
+        * Add a portfolio item
+        * Add an item to a portfolio. Returns an empty data block.
+            * @param portfolioGid Globally unique identifier for the portfolio. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> addItemForPortfolio(String portfolioGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/portfolios/{portfolio_gid}/addItem".replace("{portfolio_gid}", portfolioGid);
 
-            /**
-            * Add a portfolio item
-            * Add an item to a portfolio. Returns an empty data block.
-                * @param portfolioGid Globally unique identifier for the portfolio. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> addItemForPortfolio(String portfolioGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/portfolios/{portfolio_gid}/addItem".replace("{portfolio_gid}", portfolioGid);
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            return req;
+        }
 
-                return req;
-            }
+        public ItemRequest<JsonElement> addItemForPortfolio(String portfolioGid) throws IOException {
+            return addItemForPortfolio(portfolioGid, null, false);
+        }
+        /**
+        * Add users to a portfolio
+        * Adds the specified list of users as members of the portfolio. Returns the updated portfolio record.
+            * @param portfolioGid Globally unique identifier for the portfolio. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> addMembersForPortfolio(String portfolioGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/portfolios/{portfolio_gid}/addMembers".replace("{portfolio_gid}", portfolioGid);
 
-            public ItemRequest<JsonElement> addItemForPortfolio(String portfolioGid) throws IOException {
-                return addItemForPortfolio(portfolioGid, null, false);
-            }
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-            /**
-            * Add users to a portfolio
-            * Adds the specified list of users as members of the portfolio. Returns the updated portfolio record.
-                * @param portfolioGid Globally unique identifier for the portfolio. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> addMembersForPortfolio(String portfolioGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/portfolios/{portfolio_gid}/addMembers".replace("{portfolio_gid}", portfolioGid);
+            return req;
+        }
 
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+        public ItemRequest<JsonElement> addMembersForPortfolio(String portfolioGid) throws IOException {
+            return addMembersForPortfolio(portfolioGid, null, false);
+        }
+        /**
+        * Create a portfolio
+        * Creates a new portfolio in the given workspace with the supplied name.  Note that portfolios created in the Asana UI may have some state (like the “Priority” custom field) which is automatically added to the portfolio when it is created. Portfolios created via our API will *not* be created with the same initial state to allow integrations to create their own starting state on a portfolio.
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Portfolio>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Portfolio> createPortfolio(List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/portfolios";
 
-                return req;
-            }
+            ItemRequest<Portfolio> req = new ItemRequest<Portfolio>(this, Portfolio.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-            public ItemRequest<JsonElement> addMembersForPortfolio(String portfolioGid) throws IOException {
-                return addMembersForPortfolio(portfolioGid, null, false);
-            }
+            return req;
+        }
 
-            /**
-            * Create a portfolio
-            * Creates a new portfolio in the given workspace with the supplied name.  Note that portfolios created in the Asana UI may have some state (like the “Priority” custom field) which is automatically added to the portfolio when it is created. Portfolios created via our API will *not* be created with the same initial state to allow integrations to create their own starting state on a portfolio.
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Portfolio>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Portfolio> createPortfolio(List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/portfolios";
+        public ItemRequest<Portfolio> createPortfolio() throws IOException {
+            return createPortfolio(null, false);
+        }
+        /**
+        * Delete a portfolio
+        * An existing portfolio can be deleted by making a DELETE request on the URL for that portfolio.  Returns an empty data record.
+            * @param portfolioGid Globally unique identifier for the portfolio. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> deletePortfolio(String portfolioGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/portfolios/{portfolio_gid}".replace("{portfolio_gid}", portfolioGid);
 
-                ItemRequest<Portfolio> req = new ItemRequest<Portfolio>(this, Portfolio.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                return req;
-            }
+            return req;
+        }
 
-            public ItemRequest<Portfolio> createPortfolio() throws IOException {
-                return createPortfolio(null, false);
-            }
+        public ItemRequest<JsonElement> deletePortfolio(String portfolioGid) throws IOException {
+            return deletePortfolio(portfolioGid, null, false);
+        }
+        /**
+        * Get portfolio items
+        * Get a list of the items in compact form in a portfolio.
+            * @param portfolioGid Globally unique identifier for the portfolio. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Project>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Project> getItemsForPortfolio(String portfolioGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/portfolios/{portfolio_gid}/items".replace("{portfolio_gid}", portfolioGid);
 
-            /**
-            * Delete a portfolio
-            * An existing portfolio can be deleted by making a DELETE request on the URL for that portfolio.  Returns an empty data record.
-                * @param portfolioGid Globally unique identifier for the portfolio. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> deletePortfolio(String portfolioGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/portfolios/{portfolio_gid}".replace("{portfolio_gid}", portfolioGid);
+            CollectionRequest<Project> req = new CollectionRequest<Project>(this, Project.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            return req;
+        }
 
-                return req;
-            }
+        public CollectionRequest<Project> getItemsForPortfolio(String portfolioGid) throws IOException {
+            return getItemsForPortfolio(portfolioGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Get a portfolio
+        * Returns the complete portfolio record for a single portfolio.
+            * @param portfolioGid Globally unique identifier for the portfolio. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Portfolio>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Portfolio> getPortfolio(String portfolioGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/portfolios/{portfolio_gid}".replace("{portfolio_gid}", portfolioGid);
 
-            public ItemRequest<JsonElement> deletePortfolio(String portfolioGid) throws IOException {
-                return deletePortfolio(portfolioGid, null, false);
-            }
+            ItemRequest<Portfolio> req = new ItemRequest<Portfolio>(this, Portfolio.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-            /**
-            * Get portfolio items
-            * Get a list of the items in compact form in a portfolio.
-                * @param portfolioGid Globally unique identifier for the portfolio. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Project>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Project> getItemsForPortfolio(String portfolioGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/portfolios/{portfolio_gid}/items".replace("{portfolio_gid}", portfolioGid);
+            return req;
+        }
 
-                CollectionRequest<Project> req = new CollectionRequest<Project>(this, Project.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
+        public ItemRequest<Portfolio> getPortfolio(String portfolioGid) throws IOException {
+            return getPortfolio(portfolioGid, null, false);
+        }
+        /**
+        * Get multiple portfolios
+        * Returns a list of the portfolios in compact representation that are owned by the current API user.
+            * @param owner The user who owns the portfolio. Currently, API users can only get a list of portfolios that they themselves own. (required)
+            * @param workspace The workspace or organization to filter portfolios on. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Portfolio>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Portfolio> getPortfolios(String owner, String workspace, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/portfolios";
 
-                return req;
-            }
+            CollectionRequest<Portfolio> req = new CollectionRequest<Portfolio>(this, Portfolio.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset)
+                .query("workspace", workspace)
+                .query("owner", owner);
 
-            public CollectionRequest<Project> getItemsForPortfolio(String portfolioGid) throws IOException {
-                return getItemsForPortfolio(portfolioGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
+            return req;
+        }
 
-            /**
-            * Get a portfolio
-            * Returns the complete portfolio record for a single portfolio.
-                * @param portfolioGid Globally unique identifier for the portfolio. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Portfolio>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Portfolio> getPortfolio(String portfolioGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/portfolios/{portfolio_gid}".replace("{portfolio_gid}", portfolioGid);
+        public CollectionRequest<Portfolio> getPortfolios(String owner, String workspace) throws IOException {
+            return getPortfolios(owner, workspace, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Remove a custom field from a portfolio
+        * Removes a custom field setting from a portfolio.
+            * @param portfolioGid Globally unique identifier for the portfolio. (required)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> removeCustomFieldSettingForPortfolio(String portfolioGid, Boolean optPretty) throws IOException {
+            String path = "/portfolios/{portfolio_gid}/removeCustomFieldSetting".replace("{portfolio_gid}", portfolioGid);
 
-                ItemRequest<Portfolio> req = new ItemRequest<Portfolio>(this, Portfolio.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                .query("opt_pretty", optPretty);
 
-                return req;
-            }
+            return req;
+        }
 
-            public ItemRequest<Portfolio> getPortfolio(String portfolioGid) throws IOException {
-                return getPortfolio(portfolioGid, null, false);
-            }
+        public ItemRequest<JsonElement> removeCustomFieldSettingForPortfolio(String portfolioGid) throws IOException {
+            return removeCustomFieldSettingForPortfolio(portfolioGid, false);
+        }
+        /**
+        * Remove a portfolio item
+        * Remove an item from a portfolio. Returns an empty data block.
+            * @param portfolioGid Globally unique identifier for the portfolio. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> removeItemForPortfolio(String portfolioGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/portfolios/{portfolio_gid}/removeItem".replace("{portfolio_gid}", portfolioGid);
 
-            /**
-            * Get multiple portfolios
-            * Returns a list of the portfolios in compact representation that are owned by the current API user.
-                * @param owner The user who owns the portfolio. Currently, API users can only get a list of portfolios that they themselves own. (required)
-                * @param workspace The workspace or organization to filter portfolios on. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Portfolio>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Portfolio> getPortfolios(String owner, String workspace, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/portfolios";
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                CollectionRequest<Portfolio> req = new CollectionRequest<Portfolio>(this, Portfolio.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset)
-                    .query("workspace", workspace)
-                    .query("owner", owner);
+            return req;
+        }
 
-                return req;
-            }
+        public ItemRequest<JsonElement> removeItemForPortfolio(String portfolioGid) throws IOException {
+            return removeItemForPortfolio(portfolioGid, null, false);
+        }
+        /**
+        * Remove users from a portfolio
+        * Removes the specified list of users from members of the portfolio. Returns the updated portfolio record.
+            * @param portfolioGid Globally unique identifier for the portfolio. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> removeMembersForPortfolio(String portfolioGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/portfolios/{portfolio_gid}/removeMembers".replace("{portfolio_gid}", portfolioGid);
 
-            public CollectionRequest<Portfolio> getPortfolios(String owner, String workspace) throws IOException {
-                return getPortfolios(owner, workspace, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-            /**
-            * Remove a custom field from a portfolio
-            * Removes a custom field setting from a portfolio.
-                * @param portfolioGid Globally unique identifier for the portfolio. (required)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> removeCustomFieldSettingForPortfolio(String portfolioGid, Boolean optPretty) throws IOException {
-                String path = "/portfolios/{portfolio_gid}/removeCustomFieldSetting".replace("{portfolio_gid}", portfolioGid);
+            return req;
+        }
 
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
-                    .query("opt_pretty", optPretty);
+        public ItemRequest<JsonElement> removeMembersForPortfolio(String portfolioGid) throws IOException {
+            return removeMembersForPortfolio(portfolioGid, null, false);
+        }
+        /**
+        * Update a portfolio
+        * An existing portfolio can be updated by making a PUT request on the URL for that portfolio. Only the fields provided in the &#x60;data&#x60; block will be updated; any unspecified fields will remain unchanged.  Returns the complete updated portfolio record.
+            * @param portfolioGid Globally unique identifier for the portfolio. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Portfolio>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Portfolio> updatePortfolio(String portfolioGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/portfolios/{portfolio_gid}".replace("{portfolio_gid}", portfolioGid);
 
-                return req;
-            }
+            ItemRequest<Portfolio> req = new ItemRequest<Portfolio>(this, Portfolio.class, path, "PUT")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-            public ItemRequest<JsonElement> removeCustomFieldSettingForPortfolio(String portfolioGid) throws IOException {
-                return removeCustomFieldSettingForPortfolio(portfolioGid, false);
-            }
+            return req;
+        }
 
-            /**
-            * Remove a portfolio item
-            * Remove an item from a portfolio. Returns an empty data block.
-                * @param portfolioGid Globally unique identifier for the portfolio. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> removeItemForPortfolio(String portfolioGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/portfolios/{portfolio_gid}/removeItem".replace("{portfolio_gid}", portfolioGid);
-
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<JsonElement> removeItemForPortfolio(String portfolioGid) throws IOException {
-                return removeItemForPortfolio(portfolioGid, null, false);
-            }
-
-            /**
-            * Remove users from a portfolio
-            * Removes the specified list of users from members of the portfolio. Returns the updated portfolio record.
-                * @param portfolioGid Globally unique identifier for the portfolio. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> removeMembersForPortfolio(String portfolioGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/portfolios/{portfolio_gid}/removeMembers".replace("{portfolio_gid}", portfolioGid);
-
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<JsonElement> removeMembersForPortfolio(String portfolioGid) throws IOException {
-                return removeMembersForPortfolio(portfolioGid, null, false);
-            }
-
-            /**
-            * Update a portfolio
-            * An existing portfolio can be updated by making a PUT request on the URL for that portfolio. Only the fields provided in the &#x60;data&#x60; block will be updated; any unspecified fields will remain unchanged.  Returns the complete updated portfolio record.
-                * @param portfolioGid Globally unique identifier for the portfolio. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Portfolio>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Portfolio> updatePortfolio(String portfolioGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/portfolios/{portfolio_gid}".replace("{portfolio_gid}", portfolioGid);
-
-                ItemRequest<Portfolio> req = new ItemRequest<Portfolio>(this, Portfolio.class, path, "PUT")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<Portfolio> updatePortfolio(String portfolioGid) throws IOException {
-                return updatePortfolio(portfolioGid, null, false);
-            }
-
+        public ItemRequest<Portfolio> updatePortfolio(String portfolioGid) throws IOException {
+            return updatePortfolio(portfolioGid, null, false);
+        }
     }

--- a/src/main/java/com/asana/resources/gen/PortfoliosBase.java
+++ b/src/main/java/com/asana/resources/gen/PortfoliosBase.java
@@ -2,196 +2,300 @@ package com.asana.resources.gen;
 
 import com.asana.Client;
 import com.asana.resources.Resource;
-import com.asana.models.Portfolio;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
+import com.asana.models.Portfolio;
+import com.google.gson.JsonElement;
 
-/**
- * A _portfolio_ gives a high-level overview of the status of multiple
- * initiatives in Asana.  Portfolios provide a dashboard overview of the state
- * of multiple items, including a progress report and the most recent
- * [project status](/developers/api-reference/project_statuses) update.
- *
- * Portfolios have some restrictions on size. Each portfolio has a maximum of 250
- * items and, like projects, a maximum of 20 custom fields.
- */
-public class PortfoliosBase extends Resource {
+import java.io.IOException;
+import java.util.List;
+
+    public class PortfoliosBase extends Resource {
     /**
-     * @param client Parent client instance
-     */
-    public PortfoliosBase(Client client) {
-        super(client);
+    * @param client Parent client instance
+    */
+    public PortfoliosBase(Client client) { super(client); }
+
+            /**
+            * Add a custom field to a portfolio
+            * Custom fields are associated with portfolios by way of custom field settings.  This method creates a setting for the portfolio.
+                * @param portfolioGid Globally unique identifier for the portfolio. (required)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> addCustomFieldSettingForPortfolio(String portfolioGid, Boolean optPretty) throws IOException {
+                String path = "/portfolios/{portfolio_gid}/addCustomFieldSetting".replace("{portfolio_gid}", portfolioGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                    .query("opt_pretty", optPretty);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> addCustomFieldSettingForPortfolio(String portfolioGid) throws IOException {
+                return addCustomFieldSettingForPortfolio(portfolioGid, false);
+            }
+
+            /**
+            * Add a portfolio item
+            * Add an item to a portfolio. Returns an empty data block.
+                * @param portfolioGid Globally unique identifier for the portfolio. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> addItemForPortfolio(String portfolioGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/portfolios/{portfolio_gid}/addItem".replace("{portfolio_gid}", portfolioGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> addItemForPortfolio(String portfolioGid) throws IOException {
+                return addItemForPortfolio(portfolioGid, null, false);
+            }
+
+            /**
+            * Add users to a portfolio
+            * Adds the specified list of users as members of the portfolio. Returns the updated portfolio record.
+                * @param portfolioGid Globally unique identifier for the portfolio. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> addMembersForPortfolio(String portfolioGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/portfolios/{portfolio_gid}/addMembers".replace("{portfolio_gid}", portfolioGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> addMembersForPortfolio(String portfolioGid) throws IOException {
+                return addMembersForPortfolio(portfolioGid, null, false);
+            }
+
+            /**
+            * Create a portfolio
+            * Creates a new portfolio in the given workspace with the supplied name.  Note that portfolios created in the Asana UI may have some state (like the “Priority” custom field) which is automatically added to the portfolio when it is created. Portfolios created via our API will *not* be created with the same initial state to allow integrations to create their own starting state on a portfolio.
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Portfolio>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Portfolio> createPortfolio(List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/portfolios";
+
+                ItemRequest<Portfolio> req = new ItemRequest<Portfolio>(this, Portfolio.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<Portfolio> createPortfolio() throws IOException {
+                return createPortfolio(null, false);
+            }
+
+            /**
+            * Delete a portfolio
+            * An existing portfolio can be deleted by making a DELETE request on the URL for that portfolio.  Returns an empty data record.
+                * @param portfolioGid Globally unique identifier for the portfolio. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> deletePortfolio(String portfolioGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/portfolios/{portfolio_gid}".replace("{portfolio_gid}", portfolioGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> deletePortfolio(String portfolioGid) throws IOException {
+                return deletePortfolio(portfolioGid, null, false);
+            }
+
+            /**
+            * Get portfolio items
+            * Get a list of the items in compact form in a portfolio.
+                * @param portfolioGid Globally unique identifier for the portfolio. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Project>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Project> getItemsForPortfolio(String portfolioGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/portfolios/{portfolio_gid}/items".replace("{portfolio_gid}", portfolioGid);
+
+                CollectionRequest<Project> req = new CollectionRequest<Project>(this, Project.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public CollectionRequest<Project> getItemsForPortfolio(String portfolioGid) throws IOException {
+                return getItemsForPortfolio(portfolioGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Get a portfolio
+            * Returns the complete portfolio record for a single portfolio.
+                * @param portfolioGid Globally unique identifier for the portfolio. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Portfolio>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Portfolio> getPortfolio(String portfolioGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/portfolios/{portfolio_gid}".replace("{portfolio_gid}", portfolioGid);
+
+                ItemRequest<Portfolio> req = new ItemRequest<Portfolio>(this, Portfolio.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<Portfolio> getPortfolio(String portfolioGid) throws IOException {
+                return getPortfolio(portfolioGid, null, false);
+            }
+
+            /**
+            * Get multiple portfolios
+            * Returns a list of the portfolios in compact representation that are owned by the current API user.
+                * @param owner The user who owns the portfolio. Currently, API users can only get a list of portfolios that they themselves own. (required)
+                * @param workspace The workspace or organization to filter portfolios on. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Portfolio>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Portfolio> getPortfolios(String owner, String workspace, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/portfolios";
+
+                CollectionRequest<Portfolio> req = new CollectionRequest<Portfolio>(this, Portfolio.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset)
+                    .query("workspace", workspace)
+                    .query("owner", owner);
+
+                return req;
+            }
+
+            public CollectionRequest<Portfolio> getPortfolios(String owner, String workspace) throws IOException {
+                return getPortfolios(owner, workspace, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Remove a custom field from a portfolio
+            * Removes a custom field setting from a portfolio.
+                * @param portfolioGid Globally unique identifier for the portfolio. (required)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> removeCustomFieldSettingForPortfolio(String portfolioGid, Boolean optPretty) throws IOException {
+                String path = "/portfolios/{portfolio_gid}/removeCustomFieldSetting".replace("{portfolio_gid}", portfolioGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                    .query("opt_pretty", optPretty);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> removeCustomFieldSettingForPortfolio(String portfolioGid) throws IOException {
+                return removeCustomFieldSettingForPortfolio(portfolioGid, false);
+            }
+
+            /**
+            * Remove a portfolio item
+            * Remove an item from a portfolio. Returns an empty data block.
+                * @param portfolioGid Globally unique identifier for the portfolio. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> removeItemForPortfolio(String portfolioGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/portfolios/{portfolio_gid}/removeItem".replace("{portfolio_gid}", portfolioGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> removeItemForPortfolio(String portfolioGid) throws IOException {
+                return removeItemForPortfolio(portfolioGid, null, false);
+            }
+
+            /**
+            * Remove users from a portfolio
+            * Removes the specified list of users from members of the portfolio. Returns the updated portfolio record.
+                * @param portfolioGid Globally unique identifier for the portfolio. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> removeMembersForPortfolio(String portfolioGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/portfolios/{portfolio_gid}/removeMembers".replace("{portfolio_gid}", portfolioGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> removeMembersForPortfolio(String portfolioGid) throws IOException {
+                return removeMembersForPortfolio(portfolioGid, null, false);
+            }
+
+            /**
+            * Update a portfolio
+            * An existing portfolio can be updated by making a PUT request on the URL for that portfolio. Only the fields provided in the &#x60;data&#x60; block will be updated; any unspecified fields will remain unchanged.  Returns the complete updated portfolio record.
+                * @param portfolioGid Globally unique identifier for the portfolio. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Portfolio>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Portfolio> updatePortfolio(String portfolioGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/portfolios/{portfolio_gid}".replace("{portfolio_gid}", portfolioGid);
+
+                ItemRequest<Portfolio> req = new ItemRequest<Portfolio>(this, Portfolio.class, path, "PUT")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<Portfolio> updatePortfolio(String portfolioGid) throws IOException {
+                return updatePortfolio(portfolioGid, null, false);
+            }
+
     }
-
-    /**
-     * Creates a new portfolio in the given workspace with the supplied name.
-     *
-     * Note that portfolios created in the Asana UI may have some state
-     * (like the "Priority" custom field) which is automatically added to the
-     * portfolio when it is created. Portfolios created via our API will **not**
-     * be created with the same initial state to allow integrations to create
-     * their own starting state on a portfolio.
-     *
-     * @return Request object
-     */
-    public ItemRequest<Portfolio> create() {
-
-        return new ItemRequest<Portfolio>(this, Portfolio.class, "/portfolios", "POST");
-    }
-
-    /**
-     * Returns the complete record for a single portfolio.
-     *
-     * @param  portfolio The portfolio to get.
-     * @return Request object
-     */
-    public ItemRequest<Portfolio> findById(String portfolio) {
-
-        String path = String.format("/portfolios/%s", portfolio);
-        return new ItemRequest<Portfolio>(this, Portfolio.class, path, "GET");
-    }
-
-    /**
-     * An existing portfolio can be updated by making a PUT request on the
-     * URL for that portfolio. Only the fields provided in the `data` block will be
-     * updated; any unspecified fields will remain unchanged.
-     *
-     * Returns the complete updated portfolio record.
-     *
-     * @param  portfolio The portfolio to update.
-     * @return Request object
-     */
-    public ItemRequest<Portfolio> update(String portfolio) {
-
-        String path = String.format("/portfolios/%s", portfolio);
-        return new ItemRequest<Portfolio>(this, Portfolio.class, path, "PUT");
-    }
-
-    /**
-     * An existing portfolio can be deleted by making a DELETE request
-     * on the URL for that portfolio.
-     *
-     * Returns an empty data record.
-     *
-     * @param  portfolio The portfolio to delete.
-     * @return Request object
-     */
-    public ItemRequest<Portfolio> delete(String portfolio) {
-
-        String path = String.format("/portfolios/%s", portfolio);
-        return new ItemRequest<Portfolio>(this, Portfolio.class, path, "DELETE");
-    }
-
-    /**
-     * Returns a list of the portfolios in compact representation that are owned
-     * by the current API user.
-     *
-     * @return Request object
-     */
-    public CollectionRequest<Portfolio> findAll() {
-
-        return new CollectionRequest<Portfolio>(this, Portfolio.class, "/portfolios", "GET");
-    }
-
-    /**
-     * Get a list of the items in compact form in a portfolio.
-     *
-     * @param  portfolio The portfolio from which to get the list of items.
-     * @return Request object
-     */
-    public CollectionRequest<Resource> getItems(String portfolio) {
-
-        String path = String.format("/portfolios/%s/items", portfolio);
-        return new CollectionRequest<Resource>(this, Resource.class, path, "GET");
-    }
-
-    /**
-     * Add an item to a portfolio.
-     *
-     * Returns an empty data block.
-     *
-     * @param  portfolio The portfolio to which to add an item.
-     * @return Request object
-     */
-    public ItemRequest<Portfolio> addItem(String portfolio) {
-
-        String path = String.format("/portfolios/%s/addItem", portfolio);
-        return new ItemRequest<Portfolio>(this, Portfolio.class, path, "POST");
-    }
-
-    /**
-     * Remove an item to a portfolio.
-     *
-     * Returns an empty data block.
-     *
-     * @param  portfolio The portfolio from which to remove the item.
-     * @return Request object
-     */
-    public ItemRequest<Portfolio> removeItem(String portfolio) {
-
-        String path = String.format("/portfolios/%s/removeItem", portfolio);
-        return new ItemRequest<Portfolio>(this, Portfolio.class, path, "POST");
-    }
-
-    /**
-     * Adds the specified list of users as members of the portfolio. Returns the updated portfolio record.
-     *
-     * @param  portfolio The portfolio to add members to.
-     * @return Request object
-     */
-    public ItemRequest<Portfolio> addMembers(String portfolio) {
-
-        String path = String.format("/portfolios/%s/addMembers", portfolio);
-        return new ItemRequest<Portfolio>(this, Portfolio.class, path, "POST");
-    }
-
-    /**
-     * Removes the specified list of members from the portfolio. Returns the updated portfolio record.
-     *
-     * @param  portfolio The portfolio to remove members from.
-     * @return Request object
-     */
-    public ItemRequest<Portfolio> removeMembers(String portfolio) {
-
-        String path = String.format("/portfolios/%s/removeMembers", portfolio);
-        return new ItemRequest<Portfolio>(this, Portfolio.class, path, "POST");
-    }
-
-    /**
-     * Get the custom field settings on a portfolio.
-     *
-     * @param  portfolio The portfolio from which to get the custom field settings.
-     * @return Request object
-     */
-    public CollectionRequest<Portfolio> customFieldSettings(String portfolio) {
-
-        String path = String.format("/portfolios/%s/custom_field_settings", portfolio);
-        return new CollectionRequest<Portfolio>(this, Portfolio.class, path, "GET");
-    }
-
-    /**
-     * Create a new custom field setting on the portfolio. Returns the full
-     * record for the new custom field setting.
-     *
-     * @param  portfolio The portfolio onto which to add the custom field.
-     * @return Request object
-     */
-    public ItemRequest<Portfolio> addCustomFieldSetting(String portfolio) {
-
-        String path = String.format("/portfolios/%s/addCustomFieldSetting", portfolio);
-        return new ItemRequest<Portfolio>(this, Portfolio.class, path, "POST");
-    }
-
-    /**
-     * Remove a custom field setting on the portfolio. Returns an empty data
-     * block.
-     *
-     * @param  portfolio The portfolio from which to remove the custom field.
-     * @return Request object
-     */
-    public ItemRequest<Portfolio> removeCustomFieldSetting(String portfolio) {
-
-        String path = String.format("/portfolios/%s/removeCustomFieldSetting", portfolio);
-        return new ItemRequest<Portfolio>(this, Portfolio.class, path, "POST");
-    }
-}

--- a/src/main/java/com/asana/resources/gen/ProjectMembershipsBase.java
+++ b/src/main/java/com/asana/resources/gen/ProjectMembershipsBase.java
@@ -44,7 +44,7 @@ import java.util.List;
         * Get memberships from a project
         * Returns the compact project membership records for the project.
             * @param projectGid Globally unique identifier for the project. (required)
-            * @param user The user to filter results on. (optional)
+            * @param user A string identifying a user. This can either be the string \&quot;me\&quot;, an email, or the gid of a user. (optional)
             * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
             * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
             * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)

--- a/src/main/java/com/asana/resources/gen/ProjectMembershipsBase.java
+++ b/src/main/java/com/asana/resources/gen/ProjectMembershipsBase.java
@@ -2,45 +2,70 @@ package com.asana.resources.gen;
 
 import com.asana.Client;
 import com.asana.resources.Resource;
-import com.asana.models.ProjectMembership;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
+import com.asana.models.ProjectMembership;
+import com.google.gson.JsonElement;
 
-/**
- * With the introduction of "comment-only" projects in Asana, a user's membership
- * in a project comes with associated permissions. These permissions (whether a
- * user has full access to the project or comment-only access) are accessible
- * through the project memberships endpoints described here.
- */
-public class ProjectMembershipsBase extends Resource {
+import java.io.IOException;
+import java.util.List;
+
+    public class ProjectMembershipsBase extends Resource {
     /**
-     * @param client Parent client instance
-     */
-    public ProjectMembershipsBase(Client client) {
-        super(client);
+    * @param client Parent client instance
+    */
+    public ProjectMembershipsBase(Client client) { super(client); }
+
+            /**
+            * Get a project membership
+            * Returns the complete project record for a single project membership.
+                * @param projectMembershipGid  (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<ProjectMembership>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<ProjectMembership> getProjectMembership(String projectMembershipGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/project_memberships/{project_membership_gid}".replace("{project_membership_gid}", projectMembershipGid);
+
+                ItemRequest<ProjectMembership> req = new ItemRequest<ProjectMembership>(this, ProjectMembership.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<ProjectMembership> getProjectMembership(String projectMembershipGid) throws IOException {
+                return getProjectMembership(projectMembershipGid, null, false);
+            }
+
+            /**
+            * Get memberships from a project
+            * Returns the compact project membership records for the project.
+                * @param projectGid Globally unique identifier for the project. (required)
+                * @param user The user to filter results on. (optional)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<ProjectMembership>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<ProjectMembership> getProjectMembershipsForProject(String projectGid, String user, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/projects/{project_gid}/project_memberships".replace("{project_gid}", projectGid);
+
+                CollectionRequest<ProjectMembership> req = new CollectionRequest<ProjectMembership>(this, ProjectMembership.class, path, "GET")
+                    .query("user", user)
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public CollectionRequest<ProjectMembership> getProjectMembershipsForProject(String projectGid, String user) throws IOException {
+                return getProjectMembershipsForProject(projectGid, user, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
     }
-
-    /**
-     * Returns the compact project membership records for the project.
-     *
-     * @param  project The project for which to fetch memberships.
-     * @return Request object
-     */
-    public CollectionRequest<ProjectMembership> findByProject(String project) {
-
-        String path = String.format("/projects/%s/project_memberships", project);
-        return new CollectionRequest<ProjectMembership>(this, ProjectMembership.class, path, "GET");
-    }
-
-    /**
-     * Returns the project membership record.
-     *
-     * @param  projectMembership Globally unique identifier for the project membership.
-     * @return Request object
-     */
-    public ItemRequest<ProjectMembership> findById(String projectMembership) {
-
-        String path = String.format("/project_memberships/%s", projectMembership);
-        return new ItemRequest<ProjectMembership>(this, ProjectMembership.class, path, "GET");
-    }
-}

--- a/src/main/java/com/asana/resources/gen/ProjectMembershipsBase.java
+++ b/src/main/java/com/asana/resources/gen/ProjectMembershipsBase.java
@@ -4,10 +4,12 @@ import com.asana.Client;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
-import com.asana.models.ProjectMembership;
+import com.asana.models.*;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
     public class ProjectMembershipsBase extends Resource {
@@ -16,56 +18,54 @@ import java.util.List;
     */
     public ProjectMembershipsBase(Client client) { super(client); }
 
-            /**
-            * Get a project membership
-            * Returns the complete project record for a single project membership.
-                * @param projectMembershipGid  (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<ProjectMembership>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<ProjectMembership> getProjectMembership(String projectMembershipGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/project_memberships/{project_membership_gid}".replace("{project_membership_gid}", projectMembershipGid);
+        /**
+        * Get a project membership
+        * Returns the complete project record for a single project membership.
+            * @param projectMembershipGid  (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<ProjectMembership>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<ProjectMembership> getProjectMembership(String projectMembershipGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/project_memberships/{project_membership_gid}".replace("{project_membership_gid}", projectMembershipGid);
 
-                ItemRequest<ProjectMembership> req = new ItemRequest<ProjectMembership>(this, ProjectMembership.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            ItemRequest<ProjectMembership> req = new ItemRequest<ProjectMembership>(this, ProjectMembership.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                return req;
-            }
+            return req;
+        }
 
-            public ItemRequest<ProjectMembership> getProjectMembership(String projectMembershipGid) throws IOException {
-                return getProjectMembership(projectMembershipGid, null, false);
-            }
+        public ItemRequest<ProjectMembership> getProjectMembership(String projectMembershipGid) throws IOException {
+            return getProjectMembership(projectMembershipGid, null, false);
+        }
+        /**
+        * Get memberships from a project
+        * Returns the compact project membership records for the project.
+            * @param projectGid Globally unique identifier for the project. (required)
+            * @param user The user to filter results on. (optional)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<ProjectMembership>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<ProjectMembership> getProjectMembershipsForProject(String projectGid, String user, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/projects/{project_gid}/project_memberships".replace("{project_gid}", projectGid);
 
-            /**
-            * Get memberships from a project
-            * Returns the compact project membership records for the project.
-                * @param projectGid Globally unique identifier for the project. (required)
-                * @param user The user to filter results on. (optional)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<ProjectMembership>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<ProjectMembership> getProjectMembershipsForProject(String projectGid, String user, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/projects/{project_gid}/project_memberships".replace("{project_gid}", projectGid);
+            CollectionRequest<ProjectMembership> req = new CollectionRequest<ProjectMembership>(this, ProjectMembership.class, path, "GET")
+                .query("user", user)
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-                CollectionRequest<ProjectMembership> req = new CollectionRequest<ProjectMembership>(this, ProjectMembership.class, path, "GET")
-                    .query("user", user)
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
+            return req;
+        }
 
-                return req;
-            }
-
-            public CollectionRequest<ProjectMembership> getProjectMembershipsForProject(String projectGid, String user) throws IOException {
-                return getProjectMembershipsForProject(projectGid, user, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
+        public CollectionRequest<ProjectMembership> getProjectMembershipsForProject(String projectGid, String user) throws IOException {
+            return getProjectMembershipsForProject(projectGid, user, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
     }

--- a/src/main/java/com/asana/resources/gen/ProjectStatusesBase.java
+++ b/src/main/java/com/asana/resources/gen/ProjectStatusesBase.java
@@ -1,76 +1,114 @@
 package com.asana.resources.gen;
 
 import com.asana.Client;
-import com.asana.models.ProjectStatus;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
+import com.google.gson.JsonElement;
 
-/**
- * A _project status_ is an update on the progress of a particular project, and is sent out to all project
- * followers when created. These updates include both text describing the update and a color code intended to
- * represent the overall state of the project: "green" for projects that are on track, "yellow" for projects
- * at risk, and "red" for projects that are behind.
- *
- * Project statuses can be created and deleted, but not modified.
- */
-public class ProjectStatusesBase extends Resource {
+import java.io.IOException;
+import java.util.List;
+
+    public class ProjectStatusesBase extends Resource {
     /**
-     * @param client Parent client instance
-     */
-    public ProjectStatusesBase(Client client) {
-        super(client);
+    * @param client Parent client instance
+    */
+    public ProjectStatusesBase(Client client) { super(client); }
+
+            /**
+            * Create a project status
+            * Creates a new status update on the project. Returns the full record of the newly created project status update.
+                * @param projectGid Globally unique identifier for the project. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<ProjectStatus>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<ProjectStatus> createProjectStatusForProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/projects/{project_gid}/project_statuses".replace("{project_gid}", projectGid);
+
+                ItemRequest<ProjectStatus> req = new ItemRequest<ProjectStatus>(this, ProjectStatus.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<ProjectStatus> createProjectStatusForProject(String projectGid) throws IOException {
+                return createProjectStatusForProject(projectGid, null, false);
+            }
+
+            /**
+            * Delete a project status
+            * Deletes a specific, existing project status update.  Returns an empty data record.
+                * @param projectStatusGid The project status update to get. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> deleteProjectStatus(String projectStatusGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/project_statuses/{project_status_gid}".replace("{project_status_gid}", projectStatusGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> deleteProjectStatus(String projectStatusGid) throws IOException {
+                return deleteProjectStatus(projectStatusGid, null, false);
+            }
+
+            /**
+            * Get a project status
+            * Returns the complete record for a single status update.
+                * @param projectStatusGid The project status update to get. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<ProjectStatus>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<ProjectStatus> getProjectStatus(String projectStatusGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/project_statuses/{project_status_gid}".replace("{project_status_gid}", projectStatusGid);
+
+                ItemRequest<ProjectStatus> req = new ItemRequest<ProjectStatus>(this, ProjectStatus.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<ProjectStatus> getProjectStatus(String projectStatusGid) throws IOException {
+                return getProjectStatus(projectStatusGid, null, false);
+            }
+
+            /**
+            * Get statuses from a project
+            * Returns the compact project status update records for all updates on the project.
+                * @param projectGid Globally unique identifier for the project. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<ProjectStatus>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<ProjectStatus> getProjectStatusesForProject(String projectGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/projects/{project_gid}/project_statuses".replace("{project_gid}", projectGid);
+
+                CollectionRequest<ProjectStatus> req = new CollectionRequest<ProjectStatus>(this, ProjectStatus.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public CollectionRequest<ProjectStatus> getProjectStatusesForProject(String projectGid) throws IOException {
+                return getProjectStatusesForProject(projectGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
     }
-
-    /**
-     * Creates a new status update on the project.
-     *
-     * Returns the full record of the newly created project status update.
-     *
-     * @param  project The project on which to create a status update.
-     * @return Request object
-     */
-    public ItemRequest<ProjectStatus> createInProject(String project) {
-
-        String path = String.format("/projects/%s/project_statuses", project);
-        return new ItemRequest<ProjectStatus>(this, ProjectStatus.class, path, "POST");
-    }
-
-    /**
-     * Returns the compact project status update records for all updates on the project.
-     *
-     * @param  project The project to find status updates for.
-     * @return Request object
-     */
-    public CollectionRequest<ProjectStatus> findByProject(String project) {
-
-        String path = String.format("/projects/%s/project_statuses", project);
-        return new CollectionRequest<ProjectStatus>(this, ProjectStatus.class, path, "GET");
-    }
-
-    /**
-     * Returns the complete record for a single status update.
-     *
-     * @param  projectStatus The project status update to get.
-     * @return Request object
-     */
-    public ItemRequest<ProjectStatus> findById(String projectStatus) {
-
-        String path = String.format("/project_statuses/%s", projectStatus);
-        return new ItemRequest<ProjectStatus>(this, ProjectStatus.class, path, "GET");
-    }
-
-    /**
-     * Deletes a specific, existing project status update.
-     *
-     * Returns an empty data record.
-     *
-     * @param  projectStatus The project status update to delete.
-     * @return Request object
-     */
-    public ItemRequest<ProjectStatus> delete(String projectStatus) {
-
-        String path = String.format("/project_statuses/%s", projectStatus);
-        return new ItemRequest<ProjectStatus>(this, ProjectStatus.class, path, "DELETE");
-    }
-}

--- a/src/main/java/com/asana/resources/gen/ProjectStatusesBase.java
+++ b/src/main/java/com/asana/resources/gen/ProjectStatusesBase.java
@@ -4,9 +4,12 @@ import com.asana.Client;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
+import com.asana.models.*;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
     public class ProjectStatusesBase extends Resource {
@@ -15,100 +18,96 @@ import java.util.List;
     */
     public ProjectStatusesBase(Client client) { super(client); }
 
-            /**
-            * Create a project status
-            * Creates a new status update on the project. Returns the full record of the newly created project status update.
-                * @param projectGid Globally unique identifier for the project. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<ProjectStatus>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<ProjectStatus> createProjectStatusForProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/projects/{project_gid}/project_statuses".replace("{project_gid}", projectGid);
+        /**
+        * Create a project status
+        * Creates a new status update on the project. Returns the full record of the newly created project status update.
+            * @param projectGid Globally unique identifier for the project. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<ProjectStatus>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<ProjectStatus> createProjectStatusForProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/projects/{project_gid}/project_statuses".replace("{project_gid}", projectGid);
 
-                ItemRequest<ProjectStatus> req = new ItemRequest<ProjectStatus>(this, ProjectStatus.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            ItemRequest<ProjectStatus> req = new ItemRequest<ProjectStatus>(this, ProjectStatus.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                return req;
-            }
+            return req;
+        }
 
-            public ItemRequest<ProjectStatus> createProjectStatusForProject(String projectGid) throws IOException {
-                return createProjectStatusForProject(projectGid, null, false);
-            }
+        public ItemRequest<ProjectStatus> createProjectStatusForProject(String projectGid) throws IOException {
+            return createProjectStatusForProject(projectGid, null, false);
+        }
+        /**
+        * Delete a project status
+        * Deletes a specific, existing project status update.  Returns an empty data record.
+            * @param projectStatusGid The project status update to get. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> deleteProjectStatus(String projectStatusGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/project_statuses/{project_status_gid}".replace("{project_status_gid}", projectStatusGid);
 
-            /**
-            * Delete a project status
-            * Deletes a specific, existing project status update.  Returns an empty data record.
-                * @param projectStatusGid The project status update to get. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> deleteProjectStatus(String projectStatusGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/project_statuses/{project_status_gid}".replace("{project_status_gid}", projectStatusGid);
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            return req;
+        }
 
-                return req;
-            }
+        public ItemRequest<JsonElement> deleteProjectStatus(String projectStatusGid) throws IOException {
+            return deleteProjectStatus(projectStatusGid, null, false);
+        }
+        /**
+        * Get a project status
+        * Returns the complete record for a single status update.
+            * @param projectStatusGid The project status update to get. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<ProjectStatus>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<ProjectStatus> getProjectStatus(String projectStatusGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/project_statuses/{project_status_gid}".replace("{project_status_gid}", projectStatusGid);
 
-            public ItemRequest<JsonElement> deleteProjectStatus(String projectStatusGid) throws IOException {
-                return deleteProjectStatus(projectStatusGid, null, false);
-            }
+            ItemRequest<ProjectStatus> req = new ItemRequest<ProjectStatus>(this, ProjectStatus.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-            /**
-            * Get a project status
-            * Returns the complete record for a single status update.
-                * @param projectStatusGid The project status update to get. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<ProjectStatus>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<ProjectStatus> getProjectStatus(String projectStatusGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/project_statuses/{project_status_gid}".replace("{project_status_gid}", projectStatusGid);
+            return req;
+        }
 
-                ItemRequest<ProjectStatus> req = new ItemRequest<ProjectStatus>(this, ProjectStatus.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+        public ItemRequest<ProjectStatus> getProjectStatus(String projectStatusGid) throws IOException {
+            return getProjectStatus(projectStatusGid, null, false);
+        }
+        /**
+        * Get statuses from a project
+        * Returns the compact project status update records for all updates on the project.
+            * @param projectGid Globally unique identifier for the project. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<ProjectStatus>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<ProjectStatus> getProjectStatusesForProject(String projectGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/projects/{project_gid}/project_statuses".replace("{project_gid}", projectGid);
 
-                return req;
-            }
+            CollectionRequest<ProjectStatus> req = new CollectionRequest<ProjectStatus>(this, ProjectStatus.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-            public ItemRequest<ProjectStatus> getProjectStatus(String projectStatusGid) throws IOException {
-                return getProjectStatus(projectStatusGid, null, false);
-            }
+            return req;
+        }
 
-            /**
-            * Get statuses from a project
-            * Returns the compact project status update records for all updates on the project.
-                * @param projectGid Globally unique identifier for the project. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<ProjectStatus>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<ProjectStatus> getProjectStatusesForProject(String projectGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/projects/{project_gid}/project_statuses".replace("{project_gid}", projectGid);
-
-                CollectionRequest<ProjectStatus> req = new CollectionRequest<ProjectStatus>(this, ProjectStatus.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
-
-                return req;
-            }
-
-            public CollectionRequest<ProjectStatus> getProjectStatusesForProject(String projectGid) throws IOException {
-                return getProjectStatusesForProject(projectGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
+        public CollectionRequest<ProjectStatus> getProjectStatusesForProject(String projectGid) throws IOException {
+            return getProjectStatusesForProject(projectGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
     }

--- a/src/main/java/com/asana/resources/gen/ProjectsBase.java
+++ b/src/main/java/com/asana/resources/gen/ProjectsBase.java
@@ -4,10 +4,12 @@ import com.asana.Client;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
-import com.asana.models.Project;
+import com.asana.models.*;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
     public class ProjectsBase extends Resource {
@@ -16,442 +18,424 @@ import java.util.List;
     */
     public ProjectsBase(Client client) { super(client); }
 
-            /**
-            * Add a custom field to a project
-            * Custom fields are associated with projects by way of custom field settings.  This method creates a setting for the project.
-                * @param projectGid Globally unique identifier for the project. (required)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> addCustomFieldSettingForProject(String projectGid, Boolean optPretty) throws IOException {
-                String path = "/projects/{project_gid}/addCustomFieldSetting".replace("{project_gid}", projectGid);
-
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
-                    .query("opt_pretty", optPretty);
-
-                return req;
-            }
-
-            public ItemRequest<JsonElement> addCustomFieldSettingForProject(String projectGid) throws IOException {
-                return addCustomFieldSettingForProject(projectGid, false);
-            }
-
-            /**
-            * Add users to a project
-            * Adds the specified list of users as followers to the project. Followers are a subset of members, therefore if the users are not already members of the project they will also become members as a result of this operation. Returns the updated project record.
-                * @param projectGid Globally unique identifier for the project. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> addFollowersForProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/projects/{project_gid}/addFollowers".replace("{project_gid}", projectGid);
-
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<JsonElement> addFollowersForProject(String projectGid) throws IOException {
-                return addFollowersForProject(projectGid, null, false);
-            }
-
-            /**
-            * Add users to a project
-            * Adds the specified list of users as members of the project. Returns the updated project record.
-                * @param projectGid Globally unique identifier for the project. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> addMembersForProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/projects/{project_gid}/addMembers".replace("{project_gid}", projectGid);
-
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<JsonElement> addMembersForProject(String projectGid) throws IOException {
-                return addMembersForProject(projectGid, null, false);
-            }
-
-            /**
-            * Create a project
-            * Create a new project in a workspace or team.  Every project is required to be created in a specific workspace or organization, and this cannot be changed once set. Note that you can use the &#x60;workspace&#x60; parameter regardless of whether or not it is an organization.  If the workspace for your project is an organization, you must also supply a &#x60;team&#x60; to share the project with.  Returns the full record of the newly created project.
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Project>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Project> createProject(List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/projects";
-
-                ItemRequest<Project> req = new ItemRequest<Project>(this, Project.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<Project> createProject() throws IOException {
-                return createProject(null, false);
-            }
-
-            /**
-            * Create a project in a team
-            * Creates a project shared with the given team.  Returns the full record of the newly created project.
-                * @param teamGid Globally unique identifier for the team. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Project>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Project> createProjectForTeam(String teamGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/teams/{team_gid}/projects".replace("{team_gid}", teamGid);
-
-                ItemRequest<Project> req = new ItemRequest<Project>(this, Project.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<Project> createProjectForTeam(String teamGid) throws IOException {
-                return createProjectForTeam(teamGid, null, false);
-            }
-
-            /**
-            * Create a project in a workspace
-            * Returns the compact project records for all projects in the workspace.  If the workspace for your project is an organization, you must also supply a team to share the project with.  Returns the full record of the newly created project.
-                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Project>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Project> createProjectForWorkspace(String workspaceGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/workspaces/{workspace_gid}/projects".replace("{workspace_gid}", workspaceGid);
-
-                ItemRequest<Project> req = new ItemRequest<Project>(this, Project.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<Project> createProjectForWorkspace(String workspaceGid) throws IOException {
-                return createProjectForWorkspace(workspaceGid, null, false);
-            }
-
-            /**
-            * Delete a project
-            * A specific, existing project can be deleted by making a DELETE request on the URL for that project.  Returns an empty data record.
-                * @param projectGid Globally unique identifier for the project. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> deleteProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/projects/{project_gid}".replace("{project_gid}", projectGid);
-
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<JsonElement> deleteProject(String projectGid) throws IOException {
-                return deleteProject(projectGid, null, false);
-            }
-
-            /**
-            * Duplicate a project
-            * Creates and returns a job that will asynchronously handle the duplication.
-                * @param projectGid Globally unique identifier for the project. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Job>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Job> duplicateProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/projects/{project_gid}/duplicate".replace("{project_gid}", projectGid);
-
-                ItemRequest<Job> req = new ItemRequest<Job>(this, Job.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<Job> duplicateProject(String projectGid) throws IOException {
-                return duplicateProject(projectGid, null, false);
-            }
-
-            /**
-            * Get a project
-            * Returns the complete project record for a single project.
-                * @param projectGid Globally unique identifier for the project. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Project>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Project> getProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/projects/{project_gid}".replace("{project_gid}", projectGid);
-
-                ItemRequest<Project> req = new ItemRequest<Project>(this, Project.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<Project> getProject(String projectGid) throws IOException {
-                return getProject(projectGid, null, false);
-            }
-
-            /**
-            * Get multiple projects
-            * Returns the compact project records for some filtered set of projects. Use one or more of the parameters provided to filter the projects returned.
-                * @param archived Only return projects whose &#x60;archived&#x60; field takes on the value of this parameter. (optional)
-                * @param team The team to filter projects on. (optional)
-                * @param workspace The workspace or organization to filter projects on. (optional)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Project>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Project> getProjects(Boolean archived, String team, String workspace, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/projects";
-
-                CollectionRequest<Project> req = new CollectionRequest<Project>(this, Project.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset)
-                    .query("workspace", workspace)
-                    .query("team", team)
-                    .query("archived", archived);
-
-                return req;
-            }
-
-            public CollectionRequest<Project> getProjects(Boolean archived, String team, String workspace) throws IOException {
-                return getProjects(archived, team, workspace, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
-            /**
-            * Get projects a task is in
-            * Returns a compact representation of all of the projects the task is in.
-                * @param taskGid The task to operate on. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Project>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Project> getProjectsForTask(String taskGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}/projects".replace("{task_gid}", taskGid);
-
-                CollectionRequest<Project> req = new CollectionRequest<Project>(this, Project.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
-
-                return req;
-            }
-
-            public CollectionRequest<Project> getProjectsForTask(String taskGid) throws IOException {
-                return getProjectsForTask(taskGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
-            /**
-            * Get a team&#x27;s projects
-            * Returns the compact project records for all projects in the team.
-                * @param teamGid Globally unique identifier for the team. (required)
-                * @param archived Only return projects whose &#x60;archived&#x60; field takes on the value of this parameter. (optional)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Project>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Project> getProjectsForTeam(String teamGid, Boolean archived, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/teams/{team_gid}/projects".replace("{team_gid}", teamGid);
-
-                CollectionRequest<Project> req = new CollectionRequest<Project>(this, Project.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset)
-                    .query("archived", archived);
-
-                return req;
-            }
-
-            public CollectionRequest<Project> getProjectsForTeam(String teamGid, Boolean archived) throws IOException {
-                return getProjectsForTeam(teamGid, archived, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
-            /**
-            * Get all projects in a workspace
-            * Returns the compact project records for all projects in the workspace.
-                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
-                * @param archived Only return projects whose &#x60;archived&#x60; field takes on the value of this parameter. (optional)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Project>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Project> getProjectsForWorkspace(String workspaceGid, Boolean archived, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/workspaces/{workspace_gid}/projects".replace("{workspace_gid}", workspaceGid);
-
-                CollectionRequest<Project> req = new CollectionRequest<Project>(this, Project.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset)
-                    .query("archived", archived);
-
-                return req;
-            }
-
-            public CollectionRequest<Project> getProjectsForWorkspace(String workspaceGid, Boolean archived) throws IOException {
-                return getProjectsForWorkspace(workspaceGid, archived, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
-            /**
-            * Get task count of a project
-            * Get an object that holds task count fields. **All fields are excluded by default**. You must [opt in](#input-output-options) using &#x60;opt_fields&#x60; to get any information from this endpoint.  This endpoint has an additional [rate limit](#standard-rate-limits) and each field counts especially high against our [cost limits](#cost-limits).  Milestones are just tasks, so they are included in the &#x60;num_tasks&#x60;, &#x60;num_incomplete_tasks&#x60;, and &#x60;num_completed_tasks&#x60; counts.
-                * @param projectGid Globally unique identifier for the project. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> getTaskCountsForProject(String projectGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/projects/{project_gid}/task_counts".replace("{project_gid}", projectGid);
-
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
-
-                return req;
-            }
-
-            public ItemRequest<JsonElement> getTaskCountsForProject(String projectGid) throws IOException {
-                return getTaskCountsForProject(projectGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
-            /**
-            * Remove a custom field from a project
-            * Removes a custom field setting from a project.
-                * @param projectGid Globally unique identifier for the project. (required)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> removeCustomFieldSettingForProject(String projectGid, Boolean optPretty) throws IOException {
-                String path = "/projects/{project_gid}/removeCustomFieldSetting".replace("{project_gid}", projectGid);
-
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
-                    .query("opt_pretty", optPretty);
-
-                return req;
-            }
-
-            public ItemRequest<JsonElement> removeCustomFieldSettingForProject(String projectGid) throws IOException {
-                return removeCustomFieldSettingForProject(projectGid, false);
-            }
-
-            /**
-            * Remove followers from a project
-            * Removes the specified list of users from following the project, this will not affect project membership status. Returns the updated project record.
-                * @param projectGid Globally unique identifier for the project. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> removeFollowersForProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/projects/{project_gid}/removeFollowers".replace("{project_gid}", projectGid);
-
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<JsonElement> removeFollowersForProject(String projectGid) throws IOException {
-                return removeFollowersForProject(projectGid, null, false);
-            }
-
-            /**
-            * Remove users from a project
-            * Removes the specified list of users from members of the project. Returns the updated project record.
-                * @param projectGid Globally unique identifier for the project. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> removeMembersForProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/projects/{project_gid}/removeMembers".replace("{project_gid}", projectGid);
-
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<JsonElement> removeMembersForProject(String projectGid) throws IOException {
-                return removeMembersForProject(projectGid, null, false);
-            }
-
-            /**
-            * Update a project
-            * A specific, existing project can be updated by making a PUT request on the URL for that project. Only the fields provided in the &#x60;data&#x60; block will be updated; any unspecified fields will remain unchanged.  When using this method, it is best to specify only those fields you wish to change, or else you may overwrite changes made by another user since you last retrieved the task.  Returns the complete updated project record.
-                * @param projectGid Globally unique identifier for the project. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Project>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Project> updateProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/projects/{project_gid}".replace("{project_gid}", projectGid);
-
-                ItemRequest<Project> req = new ItemRequest<Project>(this, Project.class, path, "PUT")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<Project> updateProject(String projectGid) throws IOException {
-                return updateProject(projectGid, null, false);
-            }
-
+        /**
+        * Add a custom field to a project
+        * Custom fields are associated with projects by way of custom field settings.  This method creates a setting for the project.
+            * @param projectGid Globally unique identifier for the project. (required)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> addCustomFieldSettingForProject(String projectGid, Boolean optPretty) throws IOException {
+            String path = "/projects/{project_gid}/addCustomFieldSetting".replace("{project_gid}", projectGid);
+
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                .query("opt_pretty", optPretty);
+
+            return req;
+        }
+
+        public ItemRequest<JsonElement> addCustomFieldSettingForProject(String projectGid) throws IOException {
+            return addCustomFieldSettingForProject(projectGid, false);
+        }
+        /**
+        * Add users to a project
+        * Adds the specified list of users as followers to the project. Followers are a subset of members, therefore if the users are not already members of the project they will also become members as a result of this operation. Returns the updated project record.
+            * @param projectGid Globally unique identifier for the project. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> addFollowersForProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/projects/{project_gid}/addFollowers".replace("{project_gid}", projectGid);
+
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public ItemRequest<JsonElement> addFollowersForProject(String projectGid) throws IOException {
+            return addFollowersForProject(projectGid, null, false);
+        }
+        /**
+        * Add users to a project
+        * Adds the specified list of users as members of the project. Returns the updated project record.
+            * @param projectGid Globally unique identifier for the project. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> addMembersForProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/projects/{project_gid}/addMembers".replace("{project_gid}", projectGid);
+
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public ItemRequest<JsonElement> addMembersForProject(String projectGid) throws IOException {
+            return addMembersForProject(projectGid, null, false);
+        }
+        /**
+        * Create a project
+        * Create a new project in a workspace or team.  Every project is required to be created in a specific workspace or organization, and this cannot be changed once set. Note that you can use the &#x60;workspace&#x60; parameter regardless of whether or not it is an organization.  If the workspace for your project is an organization, you must also supply a &#x60;team&#x60; to share the project with.  Returns the full record of the newly created project.
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Project>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Project> createProject(List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/projects";
+
+            ItemRequest<Project> req = new ItemRequest<Project>(this, Project.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public ItemRequest<Project> createProject() throws IOException {
+            return createProject(null, false);
+        }
+        /**
+        * Create a project in a team
+        * Creates a project shared with the given team.  Returns the full record of the newly created project.
+            * @param teamGid Globally unique identifier for the team. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Project>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Project> createProjectForTeam(String teamGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/teams/{team_gid}/projects".replace("{team_gid}", teamGid);
+
+            ItemRequest<Project> req = new ItemRequest<Project>(this, Project.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public ItemRequest<Project> createProjectForTeam(String teamGid) throws IOException {
+            return createProjectForTeam(teamGid, null, false);
+        }
+        /**
+        * Create a project in a workspace
+        * Returns the compact project records for all projects in the workspace.  If the workspace for your project is an organization, you must also supply a team to share the project with.  Returns the full record of the newly created project.
+            * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Project>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Project> createProjectForWorkspace(String workspaceGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/workspaces/{workspace_gid}/projects".replace("{workspace_gid}", workspaceGid);
+
+            ItemRequest<Project> req = new ItemRequest<Project>(this, Project.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public ItemRequest<Project> createProjectForWorkspace(String workspaceGid) throws IOException {
+            return createProjectForWorkspace(workspaceGid, null, false);
+        }
+        /**
+        * Delete a project
+        * A specific, existing project can be deleted by making a DELETE request on the URL for that project.  Returns an empty data record.
+            * @param projectGid Globally unique identifier for the project. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> deleteProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/projects/{project_gid}".replace("{project_gid}", projectGid);
+
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public ItemRequest<JsonElement> deleteProject(String projectGid) throws IOException {
+            return deleteProject(projectGid, null, false);
+        }
+        /**
+        * Duplicate a project
+        * Creates and returns a job that will asynchronously handle the duplication.
+            * @param projectGid Globally unique identifier for the project. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Job>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Job> duplicateProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/projects/{project_gid}/duplicate".replace("{project_gid}", projectGid);
+
+            ItemRequest<Job> req = new ItemRequest<Job>(this, Job.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public ItemRequest<Job> duplicateProject(String projectGid) throws IOException {
+            return duplicateProject(projectGid, null, false);
+        }
+        /**
+        * Get a project
+        * Returns the complete project record for a single project.
+            * @param projectGid Globally unique identifier for the project. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Project>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Project> getProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/projects/{project_gid}".replace("{project_gid}", projectGid);
+
+            ItemRequest<Project> req = new ItemRequest<Project>(this, Project.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public ItemRequest<Project> getProject(String projectGid) throws IOException {
+            return getProject(projectGid, null, false);
+        }
+        /**
+        * Get multiple projects
+        * Returns the compact project records for some filtered set of projects. Use one or more of the parameters provided to filter the projects returned.
+            * @param archived Only return projects whose &#x60;archived&#x60; field takes on the value of this parameter. (optional)
+            * @param team The team to filter projects on. (optional)
+            * @param workspace The workspace or organization to filter projects on. (optional)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Project>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Project> getProjects(Boolean archived, String team, String workspace, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/projects";
+
+            CollectionRequest<Project> req = new CollectionRequest<Project>(this, Project.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset)
+                .query("workspace", workspace)
+                .query("team", team)
+                .query("archived", archived);
+
+            return req;
+        }
+
+        public CollectionRequest<Project> getProjects(Boolean archived, String team, String workspace) throws IOException {
+            return getProjects(archived, team, workspace, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Get projects a task is in
+        * Returns a compact representation of all of the projects the task is in.
+            * @param taskGid The task to operate on. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Project>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Project> getProjectsForTask(String taskGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks/{task_gid}/projects".replace("{task_gid}", taskGid);
+
+            CollectionRequest<Project> req = new CollectionRequest<Project>(this, Project.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
+
+            return req;
+        }
+
+        public CollectionRequest<Project> getProjectsForTask(String taskGid) throws IOException {
+            return getProjectsForTask(taskGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Get a team&#x27;s projects
+        * Returns the compact project records for all projects in the team.
+            * @param teamGid Globally unique identifier for the team. (required)
+            * @param archived Only return projects whose &#x60;archived&#x60; field takes on the value of this parameter. (optional)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Project>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Project> getProjectsForTeam(String teamGid, Boolean archived, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/teams/{team_gid}/projects".replace("{team_gid}", teamGid);
+
+            CollectionRequest<Project> req = new CollectionRequest<Project>(this, Project.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset)
+                .query("archived", archived);
+
+            return req;
+        }
+
+        public CollectionRequest<Project> getProjectsForTeam(String teamGid, Boolean archived) throws IOException {
+            return getProjectsForTeam(teamGid, archived, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Get all projects in a workspace
+        * Returns the compact project records for all projects in the workspace.
+            * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+            * @param archived Only return projects whose &#x60;archived&#x60; field takes on the value of this parameter. (optional)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Project>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Project> getProjectsForWorkspace(String workspaceGid, Boolean archived, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/workspaces/{workspace_gid}/projects".replace("{workspace_gid}", workspaceGid);
+
+            CollectionRequest<Project> req = new CollectionRequest<Project>(this, Project.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset)
+                .query("archived", archived);
+
+            return req;
+        }
+
+        public CollectionRequest<Project> getProjectsForWorkspace(String workspaceGid, Boolean archived) throws IOException {
+            return getProjectsForWorkspace(workspaceGid, archived, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Get task count of a project
+        * Get an object that holds task count fields. **All fields are excluded by default**. You must [opt in](#input-output-options) using &#x60;opt_fields&#x60; to get any information from this endpoint.  This endpoint has an additional [rate limit](#standard-rate-limits) and each field counts especially high against our [cost limits](#cost-limits).  Milestones are just tasks, so they are included in the &#x60;num_tasks&#x60;, &#x60;num_incomplete_tasks&#x60;, and &#x60;num_completed_tasks&#x60; counts.
+            * @param projectGid Globally unique identifier for the project. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> getTaskCountsForProject(String projectGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/projects/{project_gid}/task_counts".replace("{project_gid}", projectGid);
+
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
+
+            return req;
+        }
+
+        public ItemRequest<JsonElement> getTaskCountsForProject(String projectGid) throws IOException {
+            return getTaskCountsForProject(projectGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Remove a custom field from a project
+        * Removes a custom field setting from a project.
+            * @param projectGid Globally unique identifier for the project. (required)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> removeCustomFieldSettingForProject(String projectGid, Boolean optPretty) throws IOException {
+            String path = "/projects/{project_gid}/removeCustomFieldSetting".replace("{project_gid}", projectGid);
+
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                .query("opt_pretty", optPretty);
+
+            return req;
+        }
+
+        public ItemRequest<JsonElement> removeCustomFieldSettingForProject(String projectGid) throws IOException {
+            return removeCustomFieldSettingForProject(projectGid, false);
+        }
+        /**
+        * Remove followers from a project
+        * Removes the specified list of users from following the project, this will not affect project membership status. Returns the updated project record.
+            * @param projectGid Globally unique identifier for the project. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> removeFollowersForProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/projects/{project_gid}/removeFollowers".replace("{project_gid}", projectGid);
+
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public ItemRequest<JsonElement> removeFollowersForProject(String projectGid) throws IOException {
+            return removeFollowersForProject(projectGid, null, false);
+        }
+        /**
+        * Remove users from a project
+        * Removes the specified list of users from members of the project. Returns the updated project record.
+            * @param projectGid Globally unique identifier for the project. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> removeMembersForProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/projects/{project_gid}/removeMembers".replace("{project_gid}", projectGid);
+
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public ItemRequest<JsonElement> removeMembersForProject(String projectGid) throws IOException {
+            return removeMembersForProject(projectGid, null, false);
+        }
+        /**
+        * Update a project
+        * A specific, existing project can be updated by making a PUT request on the URL for that project. Only the fields provided in the &#x60;data&#x60; block will be updated; any unspecified fields will remain unchanged.  When using this method, it is best to specify only those fields you wish to change, or else you may overwrite changes made by another user since you last retrieved the task.  Returns the complete updated project record.
+            * @param projectGid Globally unique identifier for the project. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Project>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Project> updateProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/projects/{project_gid}".replace("{project_gid}", projectGid);
+
+            ItemRequest<Project> req = new ItemRequest<Project>(this, Project.class, path, "PUT")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public ItemRequest<Project> updateProject(String projectGid) throws IOException {
+            return updateProject(projectGid, null, false);
+        }
     }

--- a/src/main/java/com/asana/resources/gen/ProjectsBase.java
+++ b/src/main/java/com/asana/resources/gen/ProjectsBase.java
@@ -39,7 +39,7 @@ import java.util.List;
             return addCustomFieldSettingForProject(projectGid, false);
         }
         /**
-        * Add users to a project
+        * Add followers to a project
         * Adds the specified list of users as followers to the project. Followers are a subset of members, therefore if the users are not already members of the project they will also become members as a result of this operation. Returns the updated project record.
             * @param projectGid Globally unique identifier for the project. (required)
             * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)

--- a/src/main/java/com/asana/resources/gen/ProjectsBase.java
+++ b/src/main/java/com/asana/resources/gen/ProjectsBase.java
@@ -1,259 +1,457 @@
 package com.asana.resources.gen;
 
 import com.asana.Client;
-import com.asana.models.Job;
 import com.asana.resources.Resource;
-import com.asana.models.Project;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
+import com.asana.models.Project;
+import com.google.gson.JsonElement;
 
-/**
- * A _project_ represents a prioritized list of tasks in Asana or a board with
- * columns of tasks represented as cards. It exists in a single workspace or
- * organization and is accessible to a subset of users in that workspace or
- * organization, depending on its permissions.
- *
- * Projects in organizations are shared with a single team. You cannot currently
- * change the team of a project via the API. Non-organization workspaces do not
- * have teams and so you should not specify the team of project in a regular
- * workspace.
- */
-public class ProjectsBase extends Resource {
+import java.io.IOException;
+import java.util.List;
+
+    public class ProjectsBase extends Resource {
     /**
-     * @param client Parent client instance
-     */
-    public ProjectsBase(Client client) {
-        super(client);
+    * @param client Parent client instance
+    */
+    public ProjectsBase(Client client) { super(client); }
+
+            /**
+            * Add a custom field to a project
+            * Custom fields are associated with projects by way of custom field settings.  This method creates a setting for the project.
+                * @param projectGid Globally unique identifier for the project. (required)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> addCustomFieldSettingForProject(String projectGid, Boolean optPretty) throws IOException {
+                String path = "/projects/{project_gid}/addCustomFieldSetting".replace("{project_gid}", projectGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                    .query("opt_pretty", optPretty);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> addCustomFieldSettingForProject(String projectGid) throws IOException {
+                return addCustomFieldSettingForProject(projectGid, false);
+            }
+
+            /**
+            * Add users to a project
+            * Adds the specified list of users as followers to the project. Followers are a subset of members, therefore if the users are not already members of the project they will also become members as a result of this operation. Returns the updated project record.
+                * @param projectGid Globally unique identifier for the project. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> addFollowersForProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/projects/{project_gid}/addFollowers".replace("{project_gid}", projectGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> addFollowersForProject(String projectGid) throws IOException {
+                return addFollowersForProject(projectGid, null, false);
+            }
+
+            /**
+            * Add users to a project
+            * Adds the specified list of users as members of the project. Returns the updated project record.
+                * @param projectGid Globally unique identifier for the project. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> addMembersForProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/projects/{project_gid}/addMembers".replace("{project_gid}", projectGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> addMembersForProject(String projectGid) throws IOException {
+                return addMembersForProject(projectGid, null, false);
+            }
+
+            /**
+            * Create a project
+            * Create a new project in a workspace or team.  Every project is required to be created in a specific workspace or organization, and this cannot be changed once set. Note that you can use the &#x60;workspace&#x60; parameter regardless of whether or not it is an organization.  If the workspace for your project is an organization, you must also supply a &#x60;team&#x60; to share the project with.  Returns the full record of the newly created project.
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Project>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Project> createProject(List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/projects";
+
+                ItemRequest<Project> req = new ItemRequest<Project>(this, Project.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<Project> createProject() throws IOException {
+                return createProject(null, false);
+            }
+
+            /**
+            * Create a project in a team
+            * Creates a project shared with the given team.  Returns the full record of the newly created project.
+                * @param teamGid Globally unique identifier for the team. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Project>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Project> createProjectForTeam(String teamGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/teams/{team_gid}/projects".replace("{team_gid}", teamGid);
+
+                ItemRequest<Project> req = new ItemRequest<Project>(this, Project.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<Project> createProjectForTeam(String teamGid) throws IOException {
+                return createProjectForTeam(teamGid, null, false);
+            }
+
+            /**
+            * Create a project in a workspace
+            * Returns the compact project records for all projects in the workspace.  If the workspace for your project is an organization, you must also supply a team to share the project with.  Returns the full record of the newly created project.
+                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Project>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Project> createProjectForWorkspace(String workspaceGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/workspaces/{workspace_gid}/projects".replace("{workspace_gid}", workspaceGid);
+
+                ItemRequest<Project> req = new ItemRequest<Project>(this, Project.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<Project> createProjectForWorkspace(String workspaceGid) throws IOException {
+                return createProjectForWorkspace(workspaceGid, null, false);
+            }
+
+            /**
+            * Delete a project
+            * A specific, existing project can be deleted by making a DELETE request on the URL for that project.  Returns an empty data record.
+                * @param projectGid Globally unique identifier for the project. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> deleteProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/projects/{project_gid}".replace("{project_gid}", projectGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> deleteProject(String projectGid) throws IOException {
+                return deleteProject(projectGid, null, false);
+            }
+
+            /**
+            * Duplicate a project
+            * Creates and returns a job that will asynchronously handle the duplication.
+                * @param projectGid Globally unique identifier for the project. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Job>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Job> duplicateProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/projects/{project_gid}/duplicate".replace("{project_gid}", projectGid);
+
+                ItemRequest<Job> req = new ItemRequest<Job>(this, Job.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<Job> duplicateProject(String projectGid) throws IOException {
+                return duplicateProject(projectGid, null, false);
+            }
+
+            /**
+            * Get a project
+            * Returns the complete project record for a single project.
+                * @param projectGid Globally unique identifier for the project. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Project>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Project> getProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/projects/{project_gid}".replace("{project_gid}", projectGid);
+
+                ItemRequest<Project> req = new ItemRequest<Project>(this, Project.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<Project> getProject(String projectGid) throws IOException {
+                return getProject(projectGid, null, false);
+            }
+
+            /**
+            * Get multiple projects
+            * Returns the compact project records for some filtered set of projects. Use one or more of the parameters provided to filter the projects returned.
+                * @param archived Only return projects whose &#x60;archived&#x60; field takes on the value of this parameter. (optional)
+                * @param team The team to filter projects on. (optional)
+                * @param workspace The workspace or organization to filter projects on. (optional)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Project>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Project> getProjects(Boolean archived, String team, String workspace, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/projects";
+
+                CollectionRequest<Project> req = new CollectionRequest<Project>(this, Project.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset)
+                    .query("workspace", workspace)
+                    .query("team", team)
+                    .query("archived", archived);
+
+                return req;
+            }
+
+            public CollectionRequest<Project> getProjects(Boolean archived, String team, String workspace) throws IOException {
+                return getProjects(archived, team, workspace, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Get projects a task is in
+            * Returns a compact representation of all of the projects the task is in.
+                * @param taskGid The task to operate on. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Project>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Project> getProjectsForTask(String taskGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tasks/{task_gid}/projects".replace("{task_gid}", taskGid);
+
+                CollectionRequest<Project> req = new CollectionRequest<Project>(this, Project.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public CollectionRequest<Project> getProjectsForTask(String taskGid) throws IOException {
+                return getProjectsForTask(taskGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Get a team&#x27;s projects
+            * Returns the compact project records for all projects in the team.
+                * @param teamGid Globally unique identifier for the team. (required)
+                * @param archived Only return projects whose &#x60;archived&#x60; field takes on the value of this parameter. (optional)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Project>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Project> getProjectsForTeam(String teamGid, Boolean archived, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/teams/{team_gid}/projects".replace("{team_gid}", teamGid);
+
+                CollectionRequest<Project> req = new CollectionRequest<Project>(this, Project.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset)
+                    .query("archived", archived);
+
+                return req;
+            }
+
+            public CollectionRequest<Project> getProjectsForTeam(String teamGid, Boolean archived) throws IOException {
+                return getProjectsForTeam(teamGid, archived, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Get all projects in a workspace
+            * Returns the compact project records for all projects in the workspace.
+                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+                * @param archived Only return projects whose &#x60;archived&#x60; field takes on the value of this parameter. (optional)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Project>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Project> getProjectsForWorkspace(String workspaceGid, Boolean archived, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/workspaces/{workspace_gid}/projects".replace("{workspace_gid}", workspaceGid);
+
+                CollectionRequest<Project> req = new CollectionRequest<Project>(this, Project.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset)
+                    .query("archived", archived);
+
+                return req;
+            }
+
+            public CollectionRequest<Project> getProjectsForWorkspace(String workspaceGid, Boolean archived) throws IOException {
+                return getProjectsForWorkspace(workspaceGid, archived, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Get task count of a project
+            * Get an object that holds task count fields. **All fields are excluded by default**. You must [opt in](#input-output-options) using &#x60;opt_fields&#x60; to get any information from this endpoint.  This endpoint has an additional [rate limit](#standard-rate-limits) and each field counts especially high against our [cost limits](#cost-limits).  Milestones are just tasks, so they are included in the &#x60;num_tasks&#x60;, &#x60;num_incomplete_tasks&#x60;, and &#x60;num_completed_tasks&#x60; counts.
+                * @param projectGid Globally unique identifier for the project. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> getTaskCountsForProject(String projectGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/projects/{project_gid}/task_counts".replace("{project_gid}", projectGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> getTaskCountsForProject(String projectGid) throws IOException {
+                return getTaskCountsForProject(projectGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Remove a custom field from a project
+            * Removes a custom field setting from a project.
+                * @param projectGid Globally unique identifier for the project. (required)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> removeCustomFieldSettingForProject(String projectGid, Boolean optPretty) throws IOException {
+                String path = "/projects/{project_gid}/removeCustomFieldSetting".replace("{project_gid}", projectGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                    .query("opt_pretty", optPretty);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> removeCustomFieldSettingForProject(String projectGid) throws IOException {
+                return removeCustomFieldSettingForProject(projectGid, false);
+            }
+
+            /**
+            * Remove followers from a project
+            * Removes the specified list of users from following the project, this will not affect project membership status. Returns the updated project record.
+                * @param projectGid Globally unique identifier for the project. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> removeFollowersForProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/projects/{project_gid}/removeFollowers".replace("{project_gid}", projectGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> removeFollowersForProject(String projectGid) throws IOException {
+                return removeFollowersForProject(projectGid, null, false);
+            }
+
+            /**
+            * Remove users from a project
+            * Removes the specified list of users from members of the project. Returns the updated project record.
+                * @param projectGid Globally unique identifier for the project. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> removeMembersForProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/projects/{project_gid}/removeMembers".replace("{project_gid}", projectGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> removeMembersForProject(String projectGid) throws IOException {
+                return removeMembersForProject(projectGid, null, false);
+            }
+
+            /**
+            * Update a project
+            * A specific, existing project can be updated by making a PUT request on the URL for that project. Only the fields provided in the &#x60;data&#x60; block will be updated; any unspecified fields will remain unchanged.  When using this method, it is best to specify only those fields you wish to change, or else you may overwrite changes made by another user since you last retrieved the task.  Returns the complete updated project record.
+                * @param projectGid Globally unique identifier for the project. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Project>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Project> updateProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/projects/{project_gid}".replace("{project_gid}", projectGid);
+
+                ItemRequest<Project> req = new ItemRequest<Project>(this, Project.class, path, "PUT")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<Project> updateProject(String projectGid) throws IOException {
+                return updateProject(projectGid, null, false);
+            }
+
     }
-
-    /**
-     * Creates a new project in a workspace or team.
-     *
-     * Every project is required to be created in a specific workspace or
-     * organization, and this cannot be changed once set. Note that you can use
-     * the `workspace` parameter regardless of whether or not it is an
-     * organization.
-     *
-     * If the workspace for your project _is_ an organization, you must also
-     * supply a `team` to share the project with.
-     *
-     * Returns the full record of the newly created project.
-     *
-     * @return Request object
-     */
-    public ItemRequest<Project> create() {
-
-        return new ItemRequest<Project>(this, Project.class, "/projects", "POST");
-    }
-
-    /**
-     * If the workspace for your project _is_ an organization, you must also
-     * supply a `team` to share the project with.
-     *
-     * Returns the full record of the newly created project.
-     *
-     * @param  workspace The workspace or organization to create the project in.
-     * @return Request object
-     */
-    public ItemRequest<Project> createInWorkspace(String workspace) {
-
-        String path = String.format("/workspaces/%s/projects", workspace);
-        return new ItemRequest<Project>(this, Project.class, path, "POST");
-    }
-
-    /**
-     * Creates a project shared with the given team.
-     *
-     * Returns the full record of the newly created project.
-     *
-     * @param  team The team to create the project in.
-     * @return Request object
-     */
-    public ItemRequest<Project> createInTeam(String team) {
-
-        String path = String.format("/teams/%s/projects", team);
-        return new ItemRequest<Project>(this, Project.class, path, "POST");
-    }
-
-    /**
-     * Returns the complete project record for a single project.
-     *
-     * @param  project The project to get.
-     * @return Request object
-     */
-    public ItemRequest<Project> findById(String project) {
-
-        String path = String.format("/projects/%s", project);
-        return new ItemRequest<Project>(this, Project.class, path, "GET");
-    }
-
-    /**
-     * A specific, existing project can be updated by making a PUT request on the
-     * URL for that project. Only the fields provided in the `data` block will be
-     * updated; any unspecified fields will remain unchanged.
-     *
-     * When using this method, it is best to specify only those fields you wish
-     * to change, or else you may overwrite changes made by another user since
-     * you last retrieved the task.
-     *
-     * Returns the complete updated project record.
-     *
-     * @param  project The project to update.
-     * @return Request object
-     */
-    public ItemRequest<Project> update(String project) {
-
-        String path = String.format("/projects/%s", project);
-        return new ItemRequest<Project>(this, Project.class, path, "PUT");
-    }
-
-    /**
-     * A specific, existing project can be deleted by making a DELETE request
-     * on the URL for that project.
-     *
-     * Returns an empty data record.
-     *
-     * @param  project The project to delete.
-     * @return Request object
-     */
-    public ItemRequest<Project> delete(String project) {
-
-        String path = String.format("/projects/%s", project);
-        return new ItemRequest<Project>(this, Project.class, path, "DELETE");
-    }
-
-    /**
-     * Creates and returns a job that will asynchronously handle the duplication.
-     *
-     * @param  project The project to duplicate.
-     * @return Request object
-     */
-    public ItemRequest<Job> duplicateProject(String project) {
-
-        String path = String.format("/projects/%s/duplicate", project);
-        return new ItemRequest<Job>(this, Job.class, path, "POST");
-    }
-
-    /**
-     * Returns the compact project records for some filtered set of projects.
-     * Use one or more of the parameters provided to filter the projects returned.
-     *
-     * @return Request object
-     */
-    public CollectionRequest<Project> findAll() {
-
-        return new CollectionRequest<Project>(this, Project.class, "/projects", "GET");
-    }
-
-    /**
-     * Returns the compact project records for all projects in the workspace.
-     *
-     * @param  workspace The workspace or organization to find projects in.
-     * @return Request object
-     */
-    public CollectionRequest<Project> findByWorkspace(String workspace) {
-
-        String path = String.format("/workspaces/%s/projects", workspace);
-        return new CollectionRequest<Project>(this, Project.class, path, "GET");
-    }
-
-    /**
-     * Returns the compact project records for all projects in the team.
-     *
-     * @param  team The team to find projects in.
-     * @return Request object
-     */
-    public CollectionRequest<Project> findByTeam(String team) {
-
-        String path = String.format("/teams/%s/projects", team);
-        return new CollectionRequest<Project>(this, Project.class, path, "GET");
-    }
-
-    /**
-     * Returns the compact task records for all tasks within the given project,
-     * ordered by their priority within the project. Tasks can exist in more than one project at a time.
-     *
-     * @param  project The project in which to search for tasks.
-     * @return Request object
-     */
-    public CollectionRequest<Project> tasks(String project) {
-
-        String path = String.format("/projects/%s/tasks", project);
-        return new CollectionRequest<Project>(this, Project.class, path, "GET");
-    }
-
-    /**
-     * Adds the specified list of users as followers to the project. Followers are a subset of members, therefore if
-     * the users are not already members of the project they will also become members as a result of this operation.
-     * Returns the updated project record.
-     *
-     * @param  project The project to add followers to.
-     * @return Request object
-     */
-    public ItemRequest<Project> addFollowers(String project) {
-
-        String path = String.format("/projects/%s/addFollowers", project);
-        return new ItemRequest<Project>(this, Project.class, path, "POST");
-    }
-
-    /**
-     * Removes the specified list of users from following the project, this will not affect project membership status.
-     * Returns the updated project record.
-     *
-     * @param  project The project to remove followers from.
-     * @return Request object
-     */
-    public ItemRequest<Project> removeFollowers(String project) {
-
-        String path = String.format("/projects/%s/removeFollowers", project);
-        return new ItemRequest<Project>(this, Project.class, path, "POST");
-    }
-
-    /**
-     * Adds the specified list of users as members of the project. Returns the updated project record.
-     *
-     * @param  project The project to add members to.
-     * @return Request object
-     */
-    public ItemRequest<Project> addMembers(String project) {
-
-        String path = String.format("/projects/%s/addMembers", project);
-        return new ItemRequest<Project>(this, Project.class, path, "POST");
-    }
-
-    /**
-     * Removes the specified list of members from the project. Returns the updated project record.
-     *
-     * @param  project The project to remove members from.
-     * @return Request object
-     */
-    public ItemRequest<Project> removeMembers(String project) {
-
-        String path = String.format("/projects/%s/removeMembers", project);
-        return new ItemRequest<Project>(this, Project.class, path, "POST");
-    }
-
-    /**
-     * Create a new custom field setting on the project.
-     *
-     * @param  project The project to associate the custom field with
-     * @return Request object
-     */
-    public ItemRequest<Project> addCustomFieldSetting(String project) {
-
-        String path = String.format("/projects/%s/addCustomFieldSetting", project);
-        return new ItemRequest<Project>(this, Project.class, path, "POST");
-    }
-
-    /**
-     * Remove a custom field setting on the project.
-     *
-     * @param  project The project to associate the custom field with
-     * @return Request object
-     */
-    public ItemRequest<Project> removeCustomFieldSetting(String project) {
-
-        String path = String.format("/projects/%s/removeCustomFieldSetting", project);
-        return new ItemRequest<Project>(this, Project.class, path, "POST");
-    }
-}

--- a/src/main/java/com/asana/resources/gen/SectionsBase.java
+++ b/src/main/java/com/asana/resources/gen/SectionsBase.java
@@ -2,133 +2,183 @@ package com.asana.resources.gen;
 
 import com.asana.Client;
 import com.asana.resources.Resource;
-import com.asana.models.Section;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
+import com.asana.models.Section;
+import com.google.gson.JsonElement;
 
-/**
- * A _section_ is a subdivision of a project that groups tasks together. It can
- * either be a header above a list of tasks in a list view or a column in a
- * board view of a project.
- */
-public class SectionsBase extends Resource {
+import java.io.IOException;
+import java.util.List;
+
+    public class SectionsBase extends Resource {
     /**
-     * @param client Parent client instance
-     */
-    public SectionsBase(Client client) {
-        super(client);
+    * @param client Parent client instance
+    */
+    public SectionsBase(Client client) { super(client); }
+
+            /**
+            * Add task to section
+            * Add a task to a specific, existing section. This will remove the task from other sections of the project.  The task will be inserted at the top of a section unless an insert_before or insert_after parameter is declared.  This does not work for separators (tasks with the resource_subtype of section).
+                * @param sectionGid The globally unique identifier for the section. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> addTaskForSection(String sectionGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/sections/{section_gid}/addTask".replace("{section_gid}", sectionGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> addTaskForSection(String sectionGid) throws IOException {
+                return addTaskForSection(sectionGid, null, false);
+            }
+
+            /**
+            * Create a section in a project
+            * Creates a new section in a project. Returns the full record of the newly created section.
+                * @param projectGid Globally unique identifier for the project. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Section>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Section> createSectionForProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/projects/{project_gid}/sections".replace("{project_gid}", projectGid);
+
+                ItemRequest<Section> req = new ItemRequest<Section>(this, Section.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<Section> createSectionForProject(String projectGid) throws IOException {
+                return createSectionForProject(projectGid, null, false);
+            }
+
+            /**
+            * Delete a section
+            * A specific, existing section can be deleted by making a DELETE request on the URL for that section.  Note that sections must be empty to be deleted.  The last remaining section in a board view cannot be deleted.  Returns an empty data block.
+                * @param sectionGid The globally unique identifier for the section. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> deleteSection(String sectionGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/sections/{section_gid}".replace("{section_gid}", sectionGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> deleteSection(String sectionGid) throws IOException {
+                return deleteSection(sectionGid, null, false);
+            }
+
+            /**
+            * Get a section
+            * Returns the complete record for a single section.
+                * @param sectionGid The globally unique identifier for the section. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Section>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Section> getSection(String sectionGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/sections/{section_gid}".replace("{section_gid}", sectionGid);
+
+                ItemRequest<Section> req = new ItemRequest<Section>(this, Section.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<Section> getSection(String sectionGid) throws IOException {
+                return getSection(sectionGid, null, false);
+            }
+
+            /**
+            * Get sections in a project
+            * Returns the compact records for all sections in the specified project.
+                * @param projectGid Globally unique identifier for the project. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Section>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Section> getSectionsForProject(String projectGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/projects/{project_gid}/sections".replace("{project_gid}", projectGid);
+
+                CollectionRequest<Section> req = new CollectionRequest<Section>(this, Section.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public CollectionRequest<Section> getSectionsForProject(String projectGid) throws IOException {
+                return getSectionsForProject(projectGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Move or Insert sections
+            * Move sections relative to each other in a board view. One of &#x60;before_section&#x60; or &#x60;after_section&#x60; is required.  Sections cannot be moved between projects.  Returns an empty data block.
+                * @param projectGid Globally unique identifier for the project. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> insertSectionForProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/projects/{project_gid}/sections/insert".replace("{project_gid}", projectGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> insertSectionForProject(String projectGid) throws IOException {
+                return insertSectionForProject(projectGid, null, false);
+            }
+
+            /**
+            * Update a section
+            * A specific, existing section can be updated by making a PUT request on the URL for that project. Only the fields provided in the &#x60;data&#x60; block will be updated; any unspecified fields will remain unchanged. (note that at this time, the only field that can be updated is the &#x60;name&#x60; field.)  When using this method, it is best to specify only those fields you wish to change, or else you may overwrite changes made by another user since you last retrieved the task.  Returns the complete updated section record.
+                * @param sectionGid The globally unique identifier for the section. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Section>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Section> updateSection(String sectionGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/sections/{section_gid}".replace("{section_gid}", sectionGid);
+
+                ItemRequest<Section> req = new ItemRequest<Section>(this, Section.class, path, "PUT")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<Section> updateSection(String sectionGid) throws IOException {
+                return updateSection(sectionGid, null, false);
+            }
+
     }
-
-    /**
-     * Creates a new section in a project.
-     *
-     * Returns the full record of the newly created section.
-     *
-     * @param  project The project to create the section in
-     * @return Request object
-     */
-    public ItemRequest<Section> createInProject(String project) {
-
-        String path = String.format("/projects/%s/sections", project);
-        return new ItemRequest<Section>(this, Section.class, path, "POST");
-    }
-
-    /**
-     * Returns the compact records for all sections in the specified project.
-     *
-     * @param  project The project to get sections from.
-     * @return Request object
-     */
-    public CollectionRequest<Section> findByProject(String project) {
-
-        String path = String.format("/projects/%s/sections", project);
-        return new CollectionRequest<Section>(this, Section.class, path, "GET");
-    }
-
-    /**
-     * Returns the complete record for a single section.
-     *
-     * @param  section The section to get.
-     * @return Request object
-     */
-    public ItemRequest<Section> findById(String section) {
-
-        String path = String.format("/sections/%s", section);
-        return new ItemRequest<Section>(this, Section.class, path, "GET");
-    }
-
-    /**
-     * A specific, existing section can be updated by making a PUT request on
-     * the URL for that project. Only the fields provided in the `data` block
-     * will be updated; any unspecified fields will remain unchanged. (note that
-     * at this time, the only field that can be updated is the `name` field.)
-     *
-     * When using this method, it is best to specify only those fields you wish
-     * to change, or else you may overwrite changes made by another user since
-     * you last retrieved the task.
-     *
-     * Returns the complete updated section record.
-     *
-     * @param  section The section to update.
-     * @return Request object
-     */
-    public ItemRequest<Section> update(String section) {
-
-        String path = String.format("/sections/%s", section);
-        return new ItemRequest<Section>(this, Section.class, path, "PUT");
-    }
-
-    /**
-     * A specific, existing section can be deleted by making a DELETE request
-     * on the URL for that section.
-     *
-     * Note that sections must be empty to be deleted.
-     *
-     * The last remaining section in a board view cannot be deleted.
-     *
-     * Returns an empty data block.
-     *
-     * @param  section The section to delete.
-     * @return Request object
-     */
-    public ItemRequest<Section> delete(String section) {
-
-        String path = String.format("/sections/%s", section);
-        return new ItemRequest<Section>(this, Section.class, path, "DELETE");
-    }
-
-    /**
-     * Add a task to a specific, existing section. This will remove the task from other sections of the project.
-     *
-     * The task will be inserted at the top of a section unless an `insert_before` or `insert_after` parameter is declared.
-     *
-     * This does not work for separators (tasks with the `resource_subtype` of section).
-     *
-     * @param  section The section in which to add the task
-     * @return Request object
-     */
-    public ItemRequest<Section> addTask(String section) {
-
-        String path = String.format("/sections/%s/addTask", section);
-        return new ItemRequest<Section>(this, Section.class, path, "POST");
-    }
-
-    /**
-     * Move sections relative to each other in a board view. One of
-     * `before_section` or `after_section` is required.
-     *
-     * Sections cannot be moved between projects.
-     *
-     * At this point in time, moving sections is not supported in list views, only board views.
-     *
-     * Returns an empty data block.
-     *
-     * @param  project The project in which to reorder the given section
-     * @return Request object
-     */
-    public ItemRequest<Section> insertInProject(String project) {
-
-        String path = String.format("/projects/%s/sections/insert", project);
-        return new ItemRequest<Section>(this, Section.class, path, "POST");
-    }
-}

--- a/src/main/java/com/asana/resources/gen/SectionsBase.java
+++ b/src/main/java/com/asana/resources/gen/SectionsBase.java
@@ -4,10 +4,12 @@ import com.asana.Client;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
-import com.asana.models.Section;
+import com.asana.models.*;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
     public class SectionsBase extends Resource {
@@ -16,169 +18,162 @@ import java.util.List;
     */
     public SectionsBase(Client client) { super(client); }
 
-            /**
-            * Add task to section
-            * Add a task to a specific, existing section. This will remove the task from other sections of the project.  The task will be inserted at the top of a section unless an insert_before or insert_after parameter is declared.  This does not work for separators (tasks with the resource_subtype of section).
-                * @param sectionGid The globally unique identifier for the section. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> addTaskForSection(String sectionGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/sections/{section_gid}/addTask".replace("{section_gid}", sectionGid);
+        /**
+        * Add task to section
+        * Add a task to a specific, existing section. This will remove the task from other sections of the project.  The task will be inserted at the top of a section unless an insert_before or insert_after parameter is declared.  This does not work for separators (tasks with the resource_subtype of section).
+            * @param sectionGid The globally unique identifier for the section. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> addTaskForSection(String sectionGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/sections/{section_gid}/addTask".replace("{section_gid}", sectionGid);
 
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                return req;
-            }
+            return req;
+        }
 
-            public ItemRequest<JsonElement> addTaskForSection(String sectionGid) throws IOException {
-                return addTaskForSection(sectionGid, null, false);
-            }
+        public ItemRequest<JsonElement> addTaskForSection(String sectionGid) throws IOException {
+            return addTaskForSection(sectionGid, null, false);
+        }
+        /**
+        * Create a section in a project
+        * Creates a new section in a project. Returns the full record of the newly created section.
+            * @param projectGid Globally unique identifier for the project. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Section>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Section> createSectionForProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/projects/{project_gid}/sections".replace("{project_gid}", projectGid);
 
-            /**
-            * Create a section in a project
-            * Creates a new section in a project. Returns the full record of the newly created section.
-                * @param projectGid Globally unique identifier for the project. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Section>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Section> createSectionForProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/projects/{project_gid}/sections".replace("{project_gid}", projectGid);
+            ItemRequest<Section> req = new ItemRequest<Section>(this, Section.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                ItemRequest<Section> req = new ItemRequest<Section>(this, Section.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            return req;
+        }
 
-                return req;
-            }
+        public ItemRequest<Section> createSectionForProject(String projectGid) throws IOException {
+            return createSectionForProject(projectGid, null, false);
+        }
+        /**
+        * Delete a section
+        * A specific, existing section can be deleted by making a DELETE request on the URL for that section.  Note that sections must be empty to be deleted.  The last remaining section in a board view cannot be deleted.  Returns an empty data block.
+            * @param sectionGid The globally unique identifier for the section. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> deleteSection(String sectionGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/sections/{section_gid}".replace("{section_gid}", sectionGid);
 
-            public ItemRequest<Section> createSectionForProject(String projectGid) throws IOException {
-                return createSectionForProject(projectGid, null, false);
-            }
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-            /**
-            * Delete a section
-            * A specific, existing section can be deleted by making a DELETE request on the URL for that section.  Note that sections must be empty to be deleted.  The last remaining section in a board view cannot be deleted.  Returns an empty data block.
-                * @param sectionGid The globally unique identifier for the section. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> deleteSection(String sectionGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/sections/{section_gid}".replace("{section_gid}", sectionGid);
+            return req;
+        }
 
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+        public ItemRequest<JsonElement> deleteSection(String sectionGid) throws IOException {
+            return deleteSection(sectionGid, null, false);
+        }
+        /**
+        * Get a section
+        * Returns the complete record for a single section.
+            * @param sectionGid The globally unique identifier for the section. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Section>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Section> getSection(String sectionGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/sections/{section_gid}".replace("{section_gid}", sectionGid);
 
-                return req;
-            }
+            ItemRequest<Section> req = new ItemRequest<Section>(this, Section.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-            public ItemRequest<JsonElement> deleteSection(String sectionGid) throws IOException {
-                return deleteSection(sectionGid, null, false);
-            }
+            return req;
+        }
 
-            /**
-            * Get a section
-            * Returns the complete record for a single section.
-                * @param sectionGid The globally unique identifier for the section. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Section>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Section> getSection(String sectionGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/sections/{section_gid}".replace("{section_gid}", sectionGid);
+        public ItemRequest<Section> getSection(String sectionGid) throws IOException {
+            return getSection(sectionGid, null, false);
+        }
+        /**
+        * Get sections in a project
+        * Returns the compact records for all sections in the specified project.
+            * @param projectGid Globally unique identifier for the project. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Section>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Section> getSectionsForProject(String projectGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/projects/{project_gid}/sections".replace("{project_gid}", projectGid);
 
-                ItemRequest<Section> req = new ItemRequest<Section>(this, Section.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            CollectionRequest<Section> req = new CollectionRequest<Section>(this, Section.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-                return req;
-            }
+            return req;
+        }
 
-            public ItemRequest<Section> getSection(String sectionGid) throws IOException {
-                return getSection(sectionGid, null, false);
-            }
+        public CollectionRequest<Section> getSectionsForProject(String projectGid) throws IOException {
+            return getSectionsForProject(projectGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Move or Insert sections
+        * Move sections relative to each other in a board view. One of &#x60;before_section&#x60; or &#x60;after_section&#x60; is required.  Sections cannot be moved between projects.  Returns an empty data block.
+            * @param projectGid Globally unique identifier for the project. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> insertSectionForProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/projects/{project_gid}/sections/insert".replace("{project_gid}", projectGid);
 
-            /**
-            * Get sections in a project
-            * Returns the compact records for all sections in the specified project.
-                * @param projectGid Globally unique identifier for the project. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Section>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Section> getSectionsForProject(String projectGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/projects/{project_gid}/sections".replace("{project_gid}", projectGid);
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                CollectionRequest<Section> req = new CollectionRequest<Section>(this, Section.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
+            return req;
+        }
 
-                return req;
-            }
+        public ItemRequest<JsonElement> insertSectionForProject(String projectGid) throws IOException {
+            return insertSectionForProject(projectGid, null, false);
+        }
+        /**
+        * Update a section
+        * A specific, existing section can be updated by making a PUT request on the URL for that project. Only the fields provided in the &#x60;data&#x60; block will be updated; any unspecified fields will remain unchanged. (note that at this time, the only field that can be updated is the &#x60;name&#x60; field.)  When using this method, it is best to specify only those fields you wish to change, or else you may overwrite changes made by another user since you last retrieved the task.  Returns the complete updated section record.
+            * @param sectionGid The globally unique identifier for the section. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Section>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Section> updateSection(String sectionGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/sections/{section_gid}".replace("{section_gid}", sectionGid);
 
-            public CollectionRequest<Section> getSectionsForProject(String projectGid) throws IOException {
-                return getSectionsForProject(projectGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
+            ItemRequest<Section> req = new ItemRequest<Section>(this, Section.class, path, "PUT")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-            /**
-            * Move or Insert sections
-            * Move sections relative to each other in a board view. One of &#x60;before_section&#x60; or &#x60;after_section&#x60; is required.  Sections cannot be moved between projects.  Returns an empty data block.
-                * @param projectGid Globally unique identifier for the project. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> insertSectionForProject(String projectGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/projects/{project_gid}/sections/insert".replace("{project_gid}", projectGid);
+            return req;
+        }
 
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<JsonElement> insertSectionForProject(String projectGid) throws IOException {
-                return insertSectionForProject(projectGid, null, false);
-            }
-
-            /**
-            * Update a section
-            * A specific, existing section can be updated by making a PUT request on the URL for that project. Only the fields provided in the &#x60;data&#x60; block will be updated; any unspecified fields will remain unchanged. (note that at this time, the only field that can be updated is the &#x60;name&#x60; field.)  When using this method, it is best to specify only those fields you wish to change, or else you may overwrite changes made by another user since you last retrieved the task.  Returns the complete updated section record.
-                * @param sectionGid The globally unique identifier for the section. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Section>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Section> updateSection(String sectionGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/sections/{section_gid}".replace("{section_gid}", sectionGid);
-
-                ItemRequest<Section> req = new ItemRequest<Section>(this, Section.class, path, "PUT")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<Section> updateSection(String sectionGid) throws IOException {
-                return updateSection(sectionGid, null, false);
-            }
-
+        public ItemRequest<Section> updateSection(String sectionGid) throws IOException {
+            return updateSection(sectionGid, null, false);
+        }
     }

--- a/src/main/java/com/asana/resources/gen/StoriesBase.java
+++ b/src/main/java/com/asana/resources/gen/StoriesBase.java
@@ -4,9 +4,12 @@ import com.asana.Client;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
+import com.asana.models.*;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
     public class StoriesBase extends Resource {
@@ -15,127 +18,122 @@ import java.util.List;
     */
     public StoriesBase(Client client) { super(client); }
 
-            /**
-            * Create a story on a task
-            * Adds a story to a task. This endpoint currently only allows for comment stories to be created. The comment will be authored by the currently authenticated user, and timestamped when the server receives the request.  Returns the full record for the new story added to the task.
-                * @param taskGid The task to operate on. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Story>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Story> createStoryForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}/stories".replace("{task_gid}", taskGid);
+        /**
+        * Create a story on a task
+        * Adds a story to a task. This endpoint currently only allows for comment stories to be created. The comment will be authored by the currently authenticated user, and timestamped when the server receives the request.  Returns the full record for the new story added to the task.
+            * @param taskGid The task to operate on. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Story>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Story> createStoryForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks/{task_gid}/stories".replace("{task_gid}", taskGid);
 
-                ItemRequest<Story> req = new ItemRequest<Story>(this, Story.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            ItemRequest<Story> req = new ItemRequest<Story>(this, Story.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                return req;
-            }
+            return req;
+        }
 
-            public ItemRequest<Story> createStoryForTask(String taskGid) throws IOException {
-                return createStoryForTask(taskGid, null, false);
-            }
+        public ItemRequest<Story> createStoryForTask(String taskGid) throws IOException {
+            return createStoryForTask(taskGid, null, false);
+        }
+        /**
+        * Delete a story
+        * Deletes a story. A user can only delete stories they have created.  Returns an empty data record.
+            * @param storyGid Globally unique identifier for the story. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> deleteStory(String storyGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/stories/{story_gid}".replace("{story_gid}", storyGid);
 
-            /**
-            * Delete a story
-            * Deletes a story. A user can only delete stories they have created.  Returns an empty data record.
-                * @param storyGid Globally unique identifier for the story. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> deleteStory(String storyGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/stories/{story_gid}".replace("{story_gid}", storyGid);
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            return req;
+        }
 
-                return req;
-            }
+        public ItemRequest<JsonElement> deleteStory(String storyGid) throws IOException {
+            return deleteStory(storyGid, null, false);
+        }
+        /**
+        * Get stories from a task
+        * Returns the compact records for all stories on the task.
+            * @param taskGid The task to operate on. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Story>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Story> getStoriesForTask(String taskGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks/{task_gid}/stories".replace("{task_gid}", taskGid);
 
-            public ItemRequest<JsonElement> deleteStory(String storyGid) throws IOException {
-                return deleteStory(storyGid, null, false);
-            }
+            CollectionRequest<Story> req = new CollectionRequest<Story>(this, Story.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-            /**
-            * Get stories from a task
-            * Returns the compact records for all stories on the task.
-                * @param taskGid The task to operate on. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Story>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Story> getStoriesForTask(String taskGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}/stories".replace("{task_gid}", taskGid);
+            return req;
+        }
 
-                CollectionRequest<Story> req = new CollectionRequest<Story>(this, Story.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
+        public CollectionRequest<Story> getStoriesForTask(String taskGid) throws IOException {
+            return getStoriesForTask(taskGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Get a story
+        * Returns the full record for a single story.
+            * @param storyGid Globally unique identifier for the story. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Story>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Story> getStory(String storyGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/stories/{story_gid}".replace("{story_gid}", storyGid);
 
-                return req;
-            }
+            ItemRequest<Story> req = new ItemRequest<Story>(this, Story.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-            public CollectionRequest<Story> getStoriesForTask(String taskGid) throws IOException {
-                return getStoriesForTask(taskGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
+            return req;
+        }
 
-            /**
-            * Get a story
-            * Returns the full record for a single story.
-                * @param storyGid Globally unique identifier for the story. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Story>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Story> getStory(String storyGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/stories/{story_gid}".replace("{story_gid}", storyGid);
+        public ItemRequest<Story> getStory(String storyGid) throws IOException {
+            return getStory(storyGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Update a story
+        * Updates the story and returns the full record for the updated story. Only comment stories can have their text updated, and only comment stories and attachment stories can be pinned. Only one of &#x60;text&#x60; and &#x60;html_text&#x60; can be specified.
+            * @param storyGid Globally unique identifier for the story. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Story>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Story> updateStory(String storyGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/stories/{story_gid}".replace("{story_gid}", storyGid);
 
-                ItemRequest<Story> req = new ItemRequest<Story>(this, Story.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
+            ItemRequest<Story> req = new ItemRequest<Story>(this, Story.class, path, "PUT")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                return req;
-            }
+            return req;
+        }
 
-            public ItemRequest<Story> getStory(String storyGid) throws IOException {
-                return getStory(storyGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
-            /**
-            * Update a story
-            * Updates the story and returns the full record for the updated story. Only comment stories can have their text updated, and only comment stories and attachment stories can be pinned. Only one of &#x60;text&#x60; and &#x60;html_text&#x60; can be specified.
-                * @param storyGid Globally unique identifier for the story. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Story>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Story> updateStory(String storyGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/stories/{story_gid}".replace("{story_gid}", storyGid);
-
-                ItemRequest<Story> req = new ItemRequest<Story>(this, Story.class, path, "PUT")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<Story> updateStory(String storyGid) throws IOException {
-                return updateStory(storyGid, null, false);
-            }
-
+        public ItemRequest<Story> updateStory(String storyGid) throws IOException {
+            return updateStory(storyGid, null, false);
+        }
     }

--- a/src/main/java/com/asana/resources/gen/TagsBase.java
+++ b/src/main/java/com/asana/resources/gen/TagsBase.java
@@ -4,10 +4,12 @@ import com.asana.Client;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
-import com.asana.models.Tag;
+import com.asana.models.*;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
     public class TagsBase extends Resource {
@@ -16,187 +18,180 @@ import java.util.List;
     */
     public TagsBase(Client client) { super(client); }
 
-            /**
-            * Create a tag
-            * Creates a new tag in a workspace or organization.  Every tag is required to be created in a specific workspace or organization, and this cannot be changed once set. Note that you can use the workspace parameter regardless of whether or not it is an organization.  Returns the full record of the newly created tag.
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Tag>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Tag> createTag(List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tags";
+        /**
+        * Create a tag
+        * Creates a new tag in a workspace or organization.  Every tag is required to be created in a specific workspace or organization, and this cannot be changed once set. Note that you can use the workspace parameter regardless of whether or not it is an organization.  Returns the full record of the newly created tag.
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Tag>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Tag> createTag(List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tags";
 
-                ItemRequest<Tag> req = new ItemRequest<Tag>(this, Tag.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            ItemRequest<Tag> req = new ItemRequest<Tag>(this, Tag.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                return req;
-            }
+            return req;
+        }
 
-            public ItemRequest<Tag> createTag() throws IOException {
-                return createTag(null, false);
-            }
+        public ItemRequest<Tag> createTag() throws IOException {
+            return createTag(null, false);
+        }
+        /**
+        * Create a tag in a workspace
+        * Creates a new tag in a workspace or organization.  Every tag is required to be created in a specific workspace or organization, and this cannot be changed once set. Note that you can use the workspace parameter regardless of whether or not it is an organization.  Returns the full record of the newly created tag.
+            * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Tag>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Tag> createTagForWorkspace(String workspaceGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/workspaces/{workspace_gid}/tags".replace("{workspace_gid}", workspaceGid);
 
-            /**
-            * Create a tag in a workspace
-            * Creates a new tag in a workspace or organization.  Every tag is required to be created in a specific workspace or organization, and this cannot be changed once set. Note that you can use the workspace parameter regardless of whether or not it is an organization.  Returns the full record of the newly created tag.
-                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Tag>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Tag> createTagForWorkspace(String workspaceGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/workspaces/{workspace_gid}/tags".replace("{workspace_gid}", workspaceGid);
+            ItemRequest<Tag> req = new ItemRequest<Tag>(this, Tag.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                ItemRequest<Tag> req = new ItemRequest<Tag>(this, Tag.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            return req;
+        }
 
-                return req;
-            }
+        public ItemRequest<Tag> createTagForWorkspace(String workspaceGid) throws IOException {
+            return createTagForWorkspace(workspaceGid, null, false);
+        }
+        /**
+        * Get a tag
+        * Returns the complete tag record for a single tag.
+            * @param tagGid Globally unique identifier for the tag. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Tag>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Tag> getTag(String tagGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tags/{tag_gid}".replace("{tag_gid}", tagGid);
 
-            public ItemRequest<Tag> createTagForWorkspace(String workspaceGid) throws IOException {
-                return createTagForWorkspace(workspaceGid, null, false);
-            }
+            ItemRequest<Tag> req = new ItemRequest<Tag>(this, Tag.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-            /**
-            * Get a tag
-            * Returns the complete tag record for a single tag.
-                * @param tagGid Globally unique identifier for the tag. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Tag>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Tag> getTag(String tagGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tags/{tag_gid}".replace("{tag_gid}", tagGid);
+            return req;
+        }
 
-                ItemRequest<Tag> req = new ItemRequest<Tag>(this, Tag.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
+        public ItemRequest<Tag> getTag(String tagGid) throws IOException {
+            return getTag(tagGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Get multiple tags
+        * Returns the compact tag records for some filtered set of tags. Use one or more of the parameters provided to filter the tags returned.
+            * @param archived Only return tags whose &#x60;archived&#x60; field takes on the value of this parameter. (optional)
+            * @param workspace The workspace to filter tags on. (optional)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Tag>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Tag> getTags(Boolean archived, String workspace, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tags";
 
-                return req;
-            }
+            CollectionRequest<Tag> req = new CollectionRequest<Tag>(this, Tag.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset)
+                .query("workspace", workspace)
+                .query("archived", archived);
 
-            public ItemRequest<Tag> getTag(String tagGid) throws IOException {
-                return getTag(tagGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
+            return req;
+        }
 
-            /**
-            * Get multiple tags
-            * Returns the compact tag records for some filtered set of tags. Use one or more of the parameters provided to filter the tags returned.
-                * @param archived Only return tags whose &#x60;archived&#x60; field takes on the value of this parameter. (optional)
-                * @param workspace The workspace to filter tags on. (optional)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Tag>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Tag> getTags(Boolean archived, String workspace, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tags";
+        public CollectionRequest<Tag> getTags(Boolean archived, String workspace) throws IOException {
+            return getTags(archived, workspace, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Get a task&#x27;s tags
+        * Get a compact representation of all of the tags the task has.
+            * @param taskGid The task to operate on. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Tag>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Tag> getTagsForTask(String taskGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks/{task_gid}/tags".replace("{task_gid}", taskGid);
 
-                CollectionRequest<Tag> req = new CollectionRequest<Tag>(this, Tag.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset)
-                    .query("workspace", workspace)
-                    .query("archived", archived);
+            CollectionRequest<Tag> req = new CollectionRequest<Tag>(this, Tag.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-                return req;
-            }
+            return req;
+        }
 
-            public CollectionRequest<Tag> getTags(Boolean archived, String workspace) throws IOException {
-                return getTags(archived, workspace, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
+        public CollectionRequest<Tag> getTagsForTask(String taskGid) throws IOException {
+            return getTagsForTask(taskGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Get tags in a workspace
+        * Returns the compact tag records for some filtered set of tags. Use one or more of the parameters provided to filter the tags returned.
+            * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Tag>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Tag> getTagsForWorkspace(String workspaceGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/workspaces/{workspace_gid}/tags".replace("{workspace_gid}", workspaceGid);
 
-            /**
-            * Get a task&#x27;s tags
-            * Get a compact representation of all of the tags the task has.
-                * @param taskGid The task to operate on. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Tag>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Tag> getTagsForTask(String taskGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}/tags".replace("{task_gid}", taskGid);
+            CollectionRequest<Tag> req = new CollectionRequest<Tag>(this, Tag.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-                CollectionRequest<Tag> req = new CollectionRequest<Tag>(this, Tag.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
+            return req;
+        }
 
-                return req;
-            }
+        public CollectionRequest<Tag> getTagsForWorkspace(String workspaceGid) throws IOException {
+            return getTagsForWorkspace(workspaceGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Update a tag
+        * Updates the properties of a tag. Only the fields provided in the &#x60;data&#x60; block will be updated; any unspecified fields will remain unchanged.  When using this method, it is best to specify only those fields you wish to change, or else you may overwrite changes made by another user since you last retrieved the task.  Returns the complete updated tag record.
+            * @param tagGid Globally unique identifier for the tag. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Tag>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Tag> updateTag(String tagGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tags/{tag_gid}".replace("{tag_gid}", tagGid);
 
-            public CollectionRequest<Tag> getTagsForTask(String taskGid) throws IOException {
-                return getTagsForTask(taskGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
+            ItemRequest<Tag> req = new ItemRequest<Tag>(this, Tag.class, path, "PUT")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-            /**
-            * Get tags in a workspace
-            * Returns the compact tag records for some filtered set of tags. Use one or more of the parameters provided to filter the tags returned.
-                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Tag>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Tag> getTagsForWorkspace(String workspaceGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/workspaces/{workspace_gid}/tags".replace("{workspace_gid}", workspaceGid);
+            return req;
+        }
 
-                CollectionRequest<Tag> req = new CollectionRequest<Tag>(this, Tag.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
-
-                return req;
-            }
-
-            public CollectionRequest<Tag> getTagsForWorkspace(String workspaceGid) throws IOException {
-                return getTagsForWorkspace(workspaceGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
-            /**
-            * Update a tag
-            * Updates the properties of a tag. Only the fields provided in the &#x60;data&#x60; block will be updated; any unspecified fields will remain unchanged.  When using this method, it is best to specify only those fields you wish to change, or else you may overwrite changes made by another user since you last retrieved the task.  Returns the complete updated tag record.
-                * @param tagGid Globally unique identifier for the tag. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Tag>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Tag> updateTag(String tagGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tags/{tag_gid}".replace("{tag_gid}", tagGid);
-
-                ItemRequest<Tag> req = new ItemRequest<Tag>(this, Tag.class, path, "PUT")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
-
-                return req;
-            }
-
-            public ItemRequest<Tag> updateTag(String tagGid) throws IOException {
-                return updateTag(tagGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
+        public ItemRequest<Tag> updateTag(String tagGid) throws IOException {
+            return updateTag(tagGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
     }

--- a/src/main/java/com/asana/resources/gen/TagsBase.java
+++ b/src/main/java/com/asana/resources/gen/TagsBase.java
@@ -2,129 +2,201 @@ package com.asana.resources.gen;
 
 import com.asana.Client;
 import com.asana.resources.Resource;
-import com.asana.models.Tag;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
+import com.asana.models.Tag;
+import com.google.gson.JsonElement;
 
-/**
- * A _tag_ is a label that can be attached to any task in Asana. It exists in a
- * single workspace or organization.
- *
- * Tags have some metadata associated with them, but it is possible that we will
- * simplify them in the future so it is not encouraged to rely too heavily on it.
- * Unlike projects, tags do not provide any ordering on the tasks they
- * are associated with.
- */
-public class TagsBase extends Resource {
+import java.io.IOException;
+import java.util.List;
+
+    public class TagsBase extends Resource {
     /**
-     * @param client Parent client instance
-     */
-    public TagsBase(Client client) {
-        super(client);
+    * @param client Parent client instance
+    */
+    public TagsBase(Client client) { super(client); }
+
+            /**
+            * Create a tag
+            * Creates a new tag in a workspace or organization.  Every tag is required to be created in a specific workspace or organization, and this cannot be changed once set. Note that you can use the workspace parameter regardless of whether or not it is an organization.  Returns the full record of the newly created tag.
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Tag>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Tag> createTag(List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tags";
+
+                ItemRequest<Tag> req = new ItemRequest<Tag>(this, Tag.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<Tag> createTag() throws IOException {
+                return createTag(null, false);
+            }
+
+            /**
+            * Create a tag in a workspace
+            * Creates a new tag in a workspace or organization.  Every tag is required to be created in a specific workspace or organization, and this cannot be changed once set. Note that you can use the workspace parameter regardless of whether or not it is an organization.  Returns the full record of the newly created tag.
+                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Tag>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Tag> createTagForWorkspace(String workspaceGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/workspaces/{workspace_gid}/tags".replace("{workspace_gid}", workspaceGid);
+
+                ItemRequest<Tag> req = new ItemRequest<Tag>(this, Tag.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<Tag> createTagForWorkspace(String workspaceGid) throws IOException {
+                return createTagForWorkspace(workspaceGid, null, false);
+            }
+
+            /**
+            * Get a tag
+            * Returns the complete tag record for a single tag.
+                * @param tagGid Globally unique identifier for the tag. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Tag>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Tag> getTag(String tagGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tags/{tag_gid}".replace("{tag_gid}", tagGid);
+
+                ItemRequest<Tag> req = new ItemRequest<Tag>(this, Tag.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public ItemRequest<Tag> getTag(String tagGid) throws IOException {
+                return getTag(tagGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Get multiple tags
+            * Returns the compact tag records for some filtered set of tags. Use one or more of the parameters provided to filter the tags returned.
+                * @param archived Only return tags whose &#x60;archived&#x60; field takes on the value of this parameter. (optional)
+                * @param workspace The workspace to filter tags on. (optional)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Tag>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Tag> getTags(Boolean archived, String workspace, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tags";
+
+                CollectionRequest<Tag> req = new CollectionRequest<Tag>(this, Tag.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset)
+                    .query("workspace", workspace)
+                    .query("archived", archived);
+
+                return req;
+            }
+
+            public CollectionRequest<Tag> getTags(Boolean archived, String workspace) throws IOException {
+                return getTags(archived, workspace, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Get a task&#x27;s tags
+            * Get a compact representation of all of the tags the task has.
+                * @param taskGid The task to operate on. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Tag>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Tag> getTagsForTask(String taskGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tasks/{task_gid}/tags".replace("{task_gid}", taskGid);
+
+                CollectionRequest<Tag> req = new CollectionRequest<Tag>(this, Tag.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public CollectionRequest<Tag> getTagsForTask(String taskGid) throws IOException {
+                return getTagsForTask(taskGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Get tags in a workspace
+            * Returns the compact tag records for some filtered set of tags. Use one or more of the parameters provided to filter the tags returned.
+                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Tag>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Tag> getTagsForWorkspace(String workspaceGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/workspaces/{workspace_gid}/tags".replace("{workspace_gid}", workspaceGid);
+
+                CollectionRequest<Tag> req = new CollectionRequest<Tag>(this, Tag.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public CollectionRequest<Tag> getTagsForWorkspace(String workspaceGid) throws IOException {
+                return getTagsForWorkspace(workspaceGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Update a tag
+            * Updates the properties of a tag. Only the fields provided in the &#x60;data&#x60; block will be updated; any unspecified fields will remain unchanged.  When using this method, it is best to specify only those fields you wish to change, or else you may overwrite changes made by another user since you last retrieved the task.  Returns the complete updated tag record.
+                * @param tagGid Globally unique identifier for the tag. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Tag>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Tag> updateTag(String tagGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tags/{tag_gid}".replace("{tag_gid}", tagGid);
+
+                ItemRequest<Tag> req = new ItemRequest<Tag>(this, Tag.class, path, "PUT")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public ItemRequest<Tag> updateTag(String tagGid) throws IOException {
+                return updateTag(tagGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
     }
-
-    /**
-     * Creates a new tag in a workspace or organization.
-     *
-     * Every tag is required to be created in a specific workspace or
-     * organization, and this cannot be changed once set. Note that you can use
-     * the `workspace` parameter regardless of whether or not it is an
-     * organization.
-     *
-     * Returns the full record of the newly created tag.
-     *
-     * @return Request object
-     */
-    public ItemRequest<Tag> create() {
-
-        return new ItemRequest<Tag>(this, Tag.class, "/tags", "POST");
-    }
-
-    /**
-     * Creates a new tag in a workspace or organization.
-     *
-     * Every tag is required to be created in a specific workspace or
-     * organization, and this cannot be changed once set. Note that you can use
-     * the `workspace` parameter regardless of whether or not it is an
-     * organization.
-     *
-     * Returns the full record of the newly created tag.
-     *
-     * @param  workspace The workspace or organization to create the tag in.
-     * @return Request object
-     */
-    public ItemRequest<Tag> createInWorkspace(String workspace) {
-
-        String path = String.format("/workspaces/%s/tags", workspace);
-        return new ItemRequest<Tag>(this, Tag.class, path, "POST");
-    }
-
-    /**
-     * Returns the complete tag record for a single tag.
-     *
-     * @param  tag The tag to get.
-     * @return Request object
-     */
-    public ItemRequest<Tag> findById(String tag) {
-
-        String path = String.format("/tags/%s", tag);
-        return new ItemRequest<Tag>(this, Tag.class, path, "GET");
-    }
-
-    /**
-     * Updates the properties of a tag. Only the fields provided in the `data`
-     * block will be updated; any unspecified fields will remain unchanged.
-     *
-     * When using this method, it is best to specify only those fields you wish
-     * to change, or else you may overwrite changes made by another user since
-     * you last retrieved the task.
-     *
-     * Returns the complete updated tag record.
-     *
-     * @param  tag The tag to update.
-     * @return Request object
-     */
-    public ItemRequest<Tag> update(String tag) {
-
-        String path = String.format("/tags/%s", tag);
-        return new ItemRequest<Tag>(this, Tag.class, path, "PUT");
-    }
-
-    /**
-     * A specific, existing tag can be deleted by making a DELETE request
-     * on the URL for that tag.
-     *
-     * Returns an empty data record.
-     *
-     * @param  tag The tag to delete.
-     * @return Request object
-     */
-    public ItemRequest<Tag> delete(String tag) {
-
-        String path = String.format("/tags/%s", tag);
-        return new ItemRequest<Tag>(this, Tag.class, path, "DELETE");
-    }
-
-    /**
-     * Returns the compact tag records for some filtered set of tags.
-     * Use one or more of the parameters provided to filter the tags returned.
-     *
-     * @return Request object
-     */
-    public CollectionRequest<Tag> findAll() {
-
-        return new CollectionRequest<Tag>(this, Tag.class, "/tags", "GET");
-    }
-
-    /**
-     * Returns the compact tag records for all tags in the workspace.
-     *
-     * @param  workspace The workspace or organization to find tags in.
-     * @return Request object
-     */
-    public CollectionRequest<Tag> findByWorkspace(String workspace) {
-
-        String path = String.format("/workspaces/%s/tags", workspace);
-        return new CollectionRequest<Tag>(this, Tag.class, path, "GET");
-    }
-}

--- a/src/main/java/com/asana/resources/gen/TasksBase.java
+++ b/src/main/java/com/asana/resources/gen/TasksBase.java
@@ -1,6 +1,7 @@
 package com.asana.resources.gen;
 
 import com.asana.Client;
+import com.asana.models.Job;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
@@ -8,6 +9,8 @@ import com.asana.models.Task;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
     public class TasksBase extends Resource {

--- a/src/main/java/com/asana/resources/gen/TasksBase.java
+++ b/src/main/java/com/asana/resources/gen/TasksBase.java
@@ -1,11 +1,10 @@
 package com.asana.resources.gen;
 
 import com.asana.Client;
-import com.asana.models.Job;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
-import com.asana.models.Task;
+import com.asana.models.*;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
@@ -19,756 +18,730 @@ import java.util.List;
     */
     public TasksBase(Client client) { super(client); }
 
-            /**
-            * Set dependencies for a task
-            * Marks a set of tasks as dependencies of this task, if they are not already dependencies. *A task can have at most 15 dependencies*.
-                * @param taskGid The task to operate on. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Task>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Task> addDependenciesForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}/addDependencies".replace("{task_gid}", taskGid);
-
-                CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public CollectionRequest<Task> addDependenciesForTask(String taskGid) throws IOException {
-                return addDependenciesForTask(taskGid, null, false);
-            }
-
-            /**
-            * Set dependents for a task
-            * Marks a set of tasks as dependents of this task, if they are not already dependents. *A task can have at most 30 dependents*.
-                * @param taskGid The task to operate on. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Task>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Task> addDependentsForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}/addDependents".replace("{task_gid}", taskGid);
-
-                CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public CollectionRequest<Task> addDependentsForTask(String taskGid) throws IOException {
-                return addDependentsForTask(taskGid, null, false);
-            }
-
-            /**
-            * Add followers to a task
-            * Adds followers to a task. Returns an empty data block. Each task can be associated with zero or more followers in the system. Requests to add/remove followers, if successful, will return the complete updated task record, described above.
-                * @param taskGid The task to operate on. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> addFollowersForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}/addFollowers".replace("{task_gid}", taskGid);
-
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<JsonElement> addFollowersForTask(String taskGid) throws IOException {
-                return addFollowersForTask(taskGid, null, false);
-            }
-
-            /**
-            * Add a project to a task
-            * Adds the task to the specified project, in the optional location specified. If no location arguments are given, the task will be added to the end of the project.  &#x60;addProject&#x60; can also be used to reorder a task within a project or section that already contains it.  At most one of &#x60;insert_before&#x60;, &#x60;insert_after&#x60;, or &#x60;section&#x60; should be specified. Inserting into a section in an non-order-dependent way can be done by specifying section, otherwise, to insert within a section in a particular place, specify &#x60;insert_before&#x60; or &#x60;insert_after&#x60; and a task within the section to anchor the position of this task.  Returns an empty data block.
-                * @param taskGid The task to operate on. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> addProjectForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}/addProject".replace("{task_gid}", taskGid);
-
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<JsonElement> addProjectForTask(String taskGid) throws IOException {
-                return addProjectForTask(taskGid, null, false);
-            }
-
-            /**
-            * Add a tag to a task
-            * Adds a tag to a task. Returns an empty data block.
-                * @param taskGid The task to operate on. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> addTagForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}/addTag".replace("{task_gid}", taskGid);
-
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<JsonElement> addTagForTask(String taskGid) throws IOException {
-                return addTagForTask(taskGid, null, false);
-            }
-
-            /**
-            * Create a subtask
-            * Creates a new subtask and adds it to the parent task. Returns the full record for the newly created subtask.
-                * @param taskGid The task to operate on. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Task>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Task> createSubtaskForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}/subtasks".replace("{task_gid}", taskGid);
-
-                ItemRequest<Task> req = new ItemRequest<Task>(this, Task.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<Task> createSubtaskForTask(String taskGid) throws IOException {
-                return createSubtaskForTask(taskGid, null, false);
-            }
-
-            /**
-            * Create a task
-            * Creating a new task is as easy as POSTing to the &#x60;/tasks&#x60; endpoint with a data block containing the fields you’d like to set on the task. Any unspecified fields will take on default values.  Every task is required to be created in a specific workspace, and this workspace cannot be changed once set. The workspace need not be set explicitly if you specify &#x60;projects&#x60; or a &#x60;parent&#x60; task instead.
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Task>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Task> createTask(List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks";
-
-                ItemRequest<Task> req = new ItemRequest<Task>(this, Task.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<Task> createTask() throws IOException {
-                return createTask(null, false);
-            }
-
-            /**
-            * Delete a task
-            * A specific, existing task can be deleted by making a DELETE request on the URL for that task. Deleted tasks go into the “trash” of the user making the delete request. Tasks can be recovered from the trash within a period of 30 days; afterward they are completely removed from the system.  Returns an empty data record.
-                * @param taskGid The task to operate on. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> deleteTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}".replace("{task_gid}", taskGid);
-
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<JsonElement> deleteTask(String taskGid) throws IOException {
-                return deleteTask(taskGid, null, false);
-            }
-
-            /**
-            * Duplicate a task
-            * Creates and returns a job that will asynchronously handle the duplication.
-                * @param taskGid The task to operate on. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Job>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Job> duplicateTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}/duplicate".replace("{task_gid}", taskGid);
-
-                ItemRequest<Job> req = new ItemRequest<Job>(this, Job.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<Job> duplicateTask(String taskGid) throws IOException {
-                return duplicateTask(taskGid, null, false);
-            }
-
-            /**
-            * Get dependencies from a task
-            * Returns the compact representations of all of the dependencies of a task.
-                * @param taskGid The task to operate on. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Task>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Task> getDependenciesForTask(String taskGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}/dependencies".replace("{task_gid}", taskGid);
-
-                CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
-
-                return req;
-            }
-
-            public CollectionRequest<Task> getDependenciesForTask(String taskGid) throws IOException {
-                return getDependenciesForTask(taskGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
-            /**
-            * Get dependents from a task
-            * Returns the compact representations of all of the dependents of a task.
-                * @param taskGid The task to operate on. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Task>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Task> getDependentsForTask(String taskGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}/dependents".replace("{task_gid}", taskGid);
-
-                CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
-
-                return req;
-            }
-
-            public CollectionRequest<Task> getDependentsForTask(String taskGid) throws IOException {
-                return getDependentsForTask(taskGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
-            /**
-            * Get subtasks from a task
-            * Returns a compact representation of all of the subtasks of a task.
-                * @param taskGid The task to operate on. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Task>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Task> getSubtasksForTask(String taskGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}/subtasks".replace("{task_gid}", taskGid);
-
-                CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
-
-                return req;
-            }
-
-            public CollectionRequest<Task> getSubtasksForTask(String taskGid) throws IOException {
-                return getSubtasksForTask(taskGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
-            /**
-            * Get a task
-            * Returns the complete task record for a single task.
-                * @param taskGid The task to operate on. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Task>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Task> getTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}".replace("{task_gid}", taskGid);
-
-                ItemRequest<Task> req = new ItemRequest<Task>(this, Task.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<Task> getTask(String taskGid) throws IOException {
-                return getTask(taskGid, null, false);
-            }
-
-            /**
-            * Get multiple tasks
-            * Returns the compact task records for some filtered set of tasks. Use one or more of the parameters provided to filter the tasks returned. You must specify a &#x60;project&#x60; or &#x60;tag&#x60; if you do not specify &#x60;assignee&#x60; and &#x60;workspace&#x60;.  For more complex task retrieval, use [workspaces/{workspace_gid}/tasks/search](#search-tasks-in-a-workspace).
-                * @param modifiedSince Only return tasks that have been modified since the given time.  *Note: A task is considered “modified” if any of its properties change, or associations between it and other objects are modified (e.g.  a task being added to a project). A task is not considered modified just because another object it is associated with (e.g. a subtask) is modified. Actions that count as modifying the task include assigning, renaming, completing, and adding stories.* (optional)
-                * @param completedSince Only return tasks that are either incomplete or that have been completed since this time. (optional)
-                * @param workspace The workspace to filter tasks on. *Note: If you specify &#x60;workspace&#x60;, you must also specify the &#x60;assignee&#x60; to filter on.* (optional)
-                * @param section The section to filter tasks on. *Note: Currently, this is only supported in board views.* (optional)
-                * @param project The project to filter tasks on. (optional)
-                * @param assignee The assignee to filter tasks on. *Note: If you specify &#x60;assignee&#x60;, you must also specify the &#x60;workspace&#x60; to filter on.* (optional)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Task>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Task> getTasks(OffsetDateTime modifiedSince, OffsetDateTime completedSince, String workspace, String section, String project, String assignee, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks";
-
-                CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset)
-                    .query("assignee", assignee)
-                    .query("project", project)
-                    .query("section", section)
-                    .query("workspace", workspace)
-                    .query("completed_since", completedSince)
-                    .query("modified_since", modifiedSince);
-
-                return req;
-            }
-
-            public CollectionRequest<Task> getTasks(OffsetDateTime modifiedSince, OffsetDateTime completedSince, String workspace, String section, String project, String assignee) throws IOException {
-                return getTasks(modifiedSince, completedSince, workspace, section, project, assignee, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
-            /**
-            * Get tasks from a project
-            * Returns the compact task records for all tasks within the given project, ordered by their priority within the project. Tasks can exist in more than one project at a time.
-                * @param projectGid Globally unique identifier for the project. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Task>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Task> getTasksForProject(String projectGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/projects/{project_gid}/tasks".replace("{project_gid}", projectGid);
-
-                CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
-
-                return req;
-            }
-
-            public CollectionRequest<Task> getTasksForProject(String projectGid) throws IOException {
-                return getTasksForProject(projectGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
-            /**
-            * Get tasks from a section
-            * *Board view only*: Returns the compact section records for all tasks within the given section.
-                * @param sectionGid The globally unique identifier for the section. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Task>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Task> getTasksForSection(String sectionGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/sections/{section_gid}/tasks".replace("{section_gid}", sectionGid);
-
-                CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
-
-                return req;
-            }
-
-            public CollectionRequest<Task> getTasksForSection(String sectionGid) throws IOException {
-                return getTasksForSection(sectionGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
-            /**
-            * Get tasks from a tag
-            * Returns the compact task records for all tasks with the given tag. Tasks can have more than one tag at a time.
-                * @param tagGid Globally unique identifier for the tag. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Task>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Task> getTasksForTag(String tagGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tags/{tag_gid}/tasks".replace("{tag_gid}", tagGid);
-
-                CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
-
-                return req;
-            }
-
-            public CollectionRequest<Task> getTasksForTag(String tagGid) throws IOException {
-                return getTasksForTag(tagGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
-            /**
-            * Get tasks from a user task list
-            * Returns the compact list of tasks in a user’s My Tasks list. The returned tasks will be in order within each assignee status group of &#x60;Inbox&#x60;, &#x60;Today&#x60;, and &#x60;Upcoming&#x60;. *Note: tasks in &#x60;Later&#x60; have a different ordering in the Asana web app than the other assignee status groups; this endpoint will still return them in list order in &#x60;Later&#x60; (differently than they show up in Asana, but the same order as in Asana’s mobile apps).* *Note: Access control is enforced for this endpoint as with all Asana API endpoints, meaning a user’s private tasks will be filtered out if the API-authenticated user does not have access to them.* *Note: Both complete and incomplete tasks are returned by default unless they are filtered out (for example, setting &#x60;completed_since&#x3D;now&#x60; will return only incomplete tasks, which is the default view for “My Tasks” in Asana.)*
-                * @param userTaskListGid Globally unique identifier for the user task list. (required)
-                * @param completedSince Only return tasks that are either incomplete or that have been completed since this time. Accepts a date-time string or the keyword *now*.  (optional)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Task>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Task> getTasksForUserTaskList(String userTaskListGid, String completedSince, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/user_task_lists/{user_task_list_gid}/tasks".replace("{user_task_list_gid}", userTaskListGid);
-
-                CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
-                    .query("completed_since", completedSince)
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
-
-                return req;
-            }
-
-            public CollectionRequest<Task> getTasksForUserTaskList(String userTaskListGid, String completedSince) throws IOException {
-                return getTasksForUserTaskList(userTaskListGid, completedSince, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
-            /**
-            * Unlink dependencies from a task
-            * Unlinks a set of dependencies from this task.
-                * @param taskGid The task to operate on. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Task>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Task> removeDependenciesForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}/removeDependencies".replace("{task_gid}", taskGid);
-
-                CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public CollectionRequest<Task> removeDependenciesForTask(String taskGid) throws IOException {
-                return removeDependenciesForTask(taskGid, null, false);
-            }
-
-            /**
-            * Unlink dependents from a task
-            * Unlinks a set of dependents from this task.
-                * @param taskGid The task to operate on. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Task>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Task> removeDependentsForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}/removeDependents".replace("{task_gid}", taskGid);
-
-                CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public CollectionRequest<Task> removeDependentsForTask(String taskGid) throws IOException {
-                return removeDependentsForTask(taskGid, null, false);
-            }
-
-            /**
-            * Remove followers from a task
-            * Removes each of the specified followers from the task if they are following. Returns the complete, updated record for the affected task.
-                * @param taskGid The task to operate on. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> removeFollowerForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}/removeFollowers".replace("{task_gid}", taskGid);
-
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<JsonElement> removeFollowerForTask(String taskGid) throws IOException {
-                return removeFollowerForTask(taskGid, null, false);
-            }
-
-            /**
-            * Remove a project from a task
-            * Removes the task from the specified project. The task will still exist in the system, but it will not be in the project anymore.  Returns an empty data block.
-                * @param taskGid The task to operate on. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> removeProjectForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}/removeProject".replace("{task_gid}", taskGid);
-
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<JsonElement> removeProjectForTask(String taskGid) throws IOException {
-                return removeProjectForTask(taskGid, null, false);
-            }
-
-            /**
-            * Remove a tag from a task
-            * Removes a tag from a task. Returns an empty data block.
-                * @param taskGid The task to operate on. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> removeTagForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}/removeTag".replace("{task_gid}", taskGid);
-
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<JsonElement> removeTagForTask(String taskGid) throws IOException {
-                return removeTagForTask(taskGid, null, false);
-            }
-
-            /**
-            * Search tasks in a workspace
-            * To mirror the functionality of the Asana web app&#x27;s advanced search feature, the Asana API has a task search endpoint that allows you to build complex filters to find and retrieve the exact data you need. #### Premium access Like the Asana web product&#x27;s advance search feature, this search endpoint will only be available to premium Asana users. A user is premium if any of the following is true:  - The workspace in which the search is being performed is a premium workspace - The user is a member of a premium team inside the workspace  Even if a user is only a member of a premium team inside a non-premium workspace, search will allow them to find data anywhere in the workspace, not just inside the premium team. Making a search request using credentials of a non-premium user will result in a &#x60;402 Payment Required&#x60; error. #### Pagination Search results are not stable; repeating the same query multiple times may return the data in a different order, even if the data do not change. Because of this, the traditional [pagination](https://developers.asana.com/docs/#pagination) available elsewhere in the Asana API is not available here. However, you can paginate manually by sorting the search results by their creation time and then modifying each subsequent query to exclude data you have already seen. Page sizes are limited to a maximum of 100 items, and can be specified by the &#x60;limit&#x60; query parameter. #### Eventual consistency Changes in Asana (regardless of whether they’re made though the web product or the API) are forwarded to our search infrastructure to be indexed. This process can take between 10 and 60 seconds to complete under normal operation, and longer during some production incidents. Making a change to a task that would alter its presence in a particular search query will not be reflected immediately. This is also true of the advanced search feature in the web product. #### Rate limits You may receive a &#x60;429 Too Many Requests&#x60; response if you hit any of our [rate limits](https://developers.asana.com/docs/#rate-limits). #### Custom field parameters | Parameter name | Custom field type | Accepted type | |---|---|---| | custom_fields.{gid}.is_set | All | Boolean | | custom_fields.{gid}.value | Text | String | | custom_fields.{gid}.value | Number | Number | | custom_fields.{gid}.value | Enum | Enum option ID | | custom_fields.{gid}.starts_with | Text only | String | | custom_fields.{gid}.ends_with | Text only | String | | custom_fields.{gid}.contains | Text only | String | | custom_fields.{gid}.less_than | Number only | Number | | custom_fields.{gid}.greater_than | Number only | Number |   For example, if the gid of the custom field is 12345, these query parameter to find tasks where it is set would be &#x60;custom_fields.12345.is_set&#x3D;true&#x60;. To match an exact value for an enum custom field, use the gid of the desired enum option and not the name of the enum option: &#x60;custom_fields.12345.value&#x3D;67890&#x60;.  Searching for multiple exact matches of a custom field is not supported.
-                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
-                * @param sortAscending Default &#x60;false&#x60; (optional)
-                * @param sortBy One of &#x60;due_date&#x60;, &#x60;created_at&#x60;, &#x60;completed_at&#x60;, &#x60;likes&#x60;, or &#x60;modified_at&#x60;, defaults to &#x60;modified_at&#x60; (optional)
-                * @param isSubtask Filter to subtasks (optional)
-                * @param completed Filter to completed tasks (optional)
-                * @param hasAttachment Filter to tasks with attachments (optional)
-                * @param isBlocked Filter to tasks with incomplete dependencies (optional)
-                * @param isBlocking Filter to incomplete tasks with dependents (optional)
-                * @param modifiedAtAfter ISO 8601 datetime string (optional)
-                * @param modifiedAtBefore ISO 8601 datetime string (optional)
-                * @param dueOnBefore ISO 8601 date string (optional)
-                * @param modifiedOn ISO 8601 date string or &#x60;null&#x60; (optional)
-                * @param modifiedOnAfter ISO 8601 date string (optional)
-                * @param modifiedOnBefore ISO 8601 date string (optional)
-                * @param completedAtAfter ISO 8601 datetime string (optional)
-                * @param completedAtBefore ISO 8601 datetime string (optional)
-                * @param completedOn ISO 8601 date string or &#x60;null&#x60; (optional)
-                * @param completedOnAfter ISO 8601 date string (optional)
-                * @param completedOnBefore ISO 8601 date string (optional)
-                * @param createdAtAfter ISO 8601 datetime string (optional)
-                * @param commentedOnByNot Comma-separated list of user identifiers (optional)
-                * @param createdAtBefore ISO 8601 datetime string (optional)
-                * @param createdOn ISO 8601 date string or &#x60;null&#x60; (optional)
-                * @param createdOnAfter ISO 8601 date string (optional)
-                * @param createdOnBefore ISO 8601 date string (optional)
-                * @param startOn ISO 8601 date string or &#x60;null&#x60; (optional)
-                * @param startOnAfter ISO 8601 date string (optional)
-                * @param startOnBefore ISO 8601 date string (optional)
-                * @param dueAtAfter ISO 8601 datetime string (optional)
-                * @param dueAtBefore ISO 8601 datetime string (optional)
-                * @param dueOn ISO 8601 date string or &#x60;null&#x60; (optional)
-                * @param commentedOnByAny Comma-separated list of user identifiers (optional)
-                * @param dueOnAfter ISO 8601 date string (optional)
-                * @param likedByNot Comma-separated list of user identifiers (optional)
-                * @param likedByAny Comma-separated list of user identifiers (optional)
-                * @param assignedByNot Comma-separated list of user identifiers (optional)
-                * @param assignedByAny Comma-separated list of user identifiers (optional)
-                * @param createdByNot Comma-separated list of user identifiers (optional)
-                * @param createdByAny Comma-separated list of user identifiers (optional)
-                * @param followersNot Comma-separated list of user identifiers (optional)
-                * @param followersAny Comma-separated list of user identifiers (optional)
-                * @param teamsAny Comma-separated list of team IDs (optional)
-                * @param tagsAll Comma-separated list of tag IDs (optional)
-                * @param tagsNot Comma-separated list of tag IDs (optional)
-                * @param tagsAny Comma-separated list of tag IDs (optional)
-                * @param sectionsAll Comma-separated list of section or column IDs (optional)
-                * @param sectionsNot Comma-separated list of section or column IDs (optional)
-                * @param sectionsAny Comma-separated list of section or column IDs (optional)
-                * @param projectsAll Comma-separated list of project IDs (optional)
-                * @param projectsNot Comma-separated list of project IDs (optional)
-                * @param projectsAny Comma-separated list of project IDs (optional)
-                * @param assigneeStatus One of &#x60;inbox&#x60;, &#x60;today&#x60;, &#x60;upcoming&#x60;, or &#x60;later&#x60; (optional)
-                * @param assigneeNot Comma-separated list of user identifiers (optional)
-                * @param assigneeAny Comma-separated list of user identifiers (optional)
-                * @param resourceSubtype Filters results by the task&#x27;s resource_subtype (optional)
-                * @param text Performs full-text search on both task name and description (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Task>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Task> searchTasksForWorkspace(String workspaceGid, Boolean sortAscending, String sortBy, Boolean isSubtask, Boolean completed, Boolean hasAttachment, Boolean isBlocked, Boolean isBlocking, OffsetDateTime modifiedAtAfter, OffsetDateTime modifiedAtBefore, LocalDate dueOnBefore, LocalDate modifiedOn, LocalDate modifiedOnAfter, LocalDate modifiedOnBefore, OffsetDateTime completedAtAfter, OffsetDateTime completedAtBefore, LocalDate completedOn, LocalDate completedOnAfter, LocalDate completedOnBefore, OffsetDateTime createdAtAfter, String commentedOnByNot, OffsetDateTime createdAtBefore, LocalDate createdOn, LocalDate createdOnAfter, LocalDate createdOnBefore, LocalDate startOn, LocalDate startOnAfter, LocalDate startOnBefore, OffsetDateTime dueAtAfter, OffsetDateTime dueAtBefore, LocalDate dueOn, String commentedOnByAny, LocalDate dueOnAfter, String likedByNot, String likedByAny, String assignedByNot, String assignedByAny, String createdByNot, String createdByAny, String followersNot, String followersAny, String teamsAny, String tagsAll, String tagsNot, String tagsAny, String sectionsAll, String sectionsNot, String sectionsAny, String projectsAll, String projectsNot, String projectsAny, String assigneeStatus, String assigneeNot, String assigneeAny, String resourceSubtype, String text, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/workspaces/{workspace_gid}/tasks/search".replace("{workspace_gid}", workspaceGid);
-
-                CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("text", text)
-                    .query("resource_subtype", resourceSubtype)
-                    .query("assignee.any", assigneeAny)
-                    .query("assignee.not", assigneeNot)
-                    .query("assignee_status", assigneeStatus)
-                    .query("projects.any", projectsAny)
-                    .query("projects.not", projectsNot)
-                    .query("projects.all", projectsAll)
-                    .query("sections.any", sectionsAny)
-                    .query("sections.not", sectionsNot)
-                    .query("sections.all", sectionsAll)
-                    .query("tags.any", tagsAny)
-                    .query("tags.not", tagsNot)
-                    .query("tags.all", tagsAll)
-                    .query("teams.any", teamsAny)
-                    .query("followers.any", followersAny)
-                    .query("followers.not", followersNot)
-                    .query("created_by.any", createdByAny)
-                    .query("created_by.not", createdByNot)
-                    .query("assigned_by.any", assignedByAny)
-                    .query("assigned_by.not", assignedByNot)
-                    .query("liked_by.any", likedByAny)
-                    .query("liked_by.not", likedByNot)
-                    .query("commented_on_by.any", commentedOnByAny)
-                    .query("commented_on_by.not", commentedOnByNot)
-                    .query("due_on.before", dueOnBefore)
-                    .query("due_on.after", dueOnAfter)
-                    .query("due_on", dueOn)
-                    .query("due_at.before", dueAtBefore)
-                    .query("due_at.after", dueAtAfter)
-                    .query("start_on.before", startOnBefore)
-                    .query("start_on.after", startOnAfter)
-                    .query("start_on", startOn)
-                    .query("created_on.before", createdOnBefore)
-                    .query("created_on.after", createdOnAfter)
-                    .query("created_on", createdOn)
-                    .query("created_at.before", createdAtBefore)
-                    .query("created_at.after", createdAtAfter)
-                    .query("completed_on.before", completedOnBefore)
-                    .query("completed_on.after", completedOnAfter)
-                    .query("completed_on", completedOn)
-                    .query("completed_at.before", completedAtBefore)
-                    .query("completed_at.after", completedAtAfter)
-                    .query("modified_on.before", modifiedOnBefore)
-                    .query("modified_on.after", modifiedOnAfter)
-                    .query("modified_on", modifiedOn)
-                    .query("modified_at.before", modifiedAtBefore)
-                    .query("modified_at.after", modifiedAtAfter)
-                    .query("is_blocking", isBlocking)
-                    .query("is_blocked", isBlocked)
-                    .query("has_attachment", hasAttachment)
-                    .query("completed", completed)
-                    .query("is_subtask", isSubtask)
-                    .query("sort_by", sortBy)
-                    .query("sort_ascending", sortAscending);
-
-                return req;
-            }
-
-            public CollectionRequest<Task> searchTasksForWorkspace(String workspaceGid, Boolean sortAscending, String sortBy, Boolean isSubtask, Boolean completed, Boolean hasAttachment, Boolean isBlocked, Boolean isBlocking, OffsetDateTime modifiedAtAfter, OffsetDateTime modifiedAtBefore, LocalDate dueOnBefore, LocalDate modifiedOn, LocalDate modifiedOnAfter, LocalDate modifiedOnBefore, OffsetDateTime completedAtAfter, OffsetDateTime completedAtBefore, LocalDate completedOn, LocalDate completedOnAfter, LocalDate completedOnBefore, OffsetDateTime createdAtAfter, String commentedOnByNot, OffsetDateTime createdAtBefore, LocalDate createdOn, LocalDate createdOnAfter, LocalDate createdOnBefore, LocalDate startOn, LocalDate startOnAfter, LocalDate startOnBefore, OffsetDateTime dueAtAfter, OffsetDateTime dueAtBefore, LocalDate dueOn, String commentedOnByAny, LocalDate dueOnAfter, String likedByNot, String likedByAny, String assignedByNot, String assignedByAny, String createdByNot, String createdByAny, String followersNot, String followersAny, String teamsAny, String tagsAll, String tagsNot, String tagsAny, String sectionsAll, String sectionsNot, String sectionsAny, String projectsAll, String projectsNot, String projectsAny, String assigneeStatus, String assigneeNot, String assigneeAny, String resourceSubtype, String text) throws IOException {
-                return searchTasksForWorkspace(workspaceGid, sortAscending, sortBy, isSubtask, completed, hasAttachment, isBlocked, isBlocking, modifiedAtAfter, modifiedAtBefore, dueOnBefore, modifiedOn, modifiedOnAfter, modifiedOnBefore, completedAtAfter, completedAtBefore, completedOn, completedOnAfter, completedOnBefore, createdAtAfter, commentedOnByNot, createdAtBefore, createdOn, createdOnAfter, createdOnBefore, startOn, startOnAfter, startOnBefore, dueAtAfter, dueAtBefore, dueOn, commentedOnByAny, dueOnAfter, likedByNot, likedByAny, assignedByNot, assignedByAny, createdByNot, createdByAny, followersNot, followersAny, teamsAny, tagsAll, tagsNot, tagsAny, sectionsAll, sectionsNot, sectionsAny, projectsAll, projectsNot, projectsAny, assigneeStatus, assigneeNot, assigneeAny, resourceSubtype, text, null, false);
-            }
-
-            /**
-            * Set the parent of a task
-            * parent, or no parent task at all. Returns an empty data block. When using &#x60;insert_before&#x60; and &#x60;insert_after&#x60;, at most one of those two options can be specified, and they must already be subtasks of the parent.
-                * @param taskGid The task to operate on. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Task>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Task> setParentForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}/setParent".replace("{task_gid}", taskGid);
-
-                ItemRequest<Task> req = new ItemRequest<Task>(this, Task.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<Task> setParentForTask(String taskGid) throws IOException {
-                return setParentForTask(taskGid, null, false);
-            }
-
-            /**
-            * Update a task
-            * A specific, existing task can be updated by making a PUT request on the URL for that task. Only the fields provided in the &#x60;data&#x60; block will be updated; any unspecified fields will remain unchanged.  When using this method, it is best to specify only those fields you wish to change, or else you may overwrite changes made by another user since you last retrieved the task.  Returns the complete updated task record.
-                * @param taskGid The task to operate on. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Task>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Task> updateTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}".replace("{task_gid}", taskGid);
-
-                ItemRequest<Task> req = new ItemRequest<Task>(this, Task.class, path, "PUT")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<Task> updateTask(String taskGid) throws IOException {
-                return updateTask(taskGid, null, false);
-            }
-
+        /**
+        * Set dependencies for a task
+        * Marks a set of tasks as dependencies of this task, if they are not already dependencies. *A task can have at most 15 dependencies*.
+            * @param taskGid The task to operate on. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Task>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Task> addDependenciesForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks/{task_gid}/addDependencies".replace("{task_gid}", taskGid);
+
+            CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public CollectionRequest<Task> addDependenciesForTask(String taskGid) throws IOException {
+            return addDependenciesForTask(taskGid, null, false);
+        }
+        /**
+        * Set dependents for a task
+        * Marks a set of tasks as dependents of this task, if they are not already dependents. *A task can have at most 30 dependents*.
+            * @param taskGid The task to operate on. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Task>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Task> addDependentsForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks/{task_gid}/addDependents".replace("{task_gid}", taskGid);
+
+            CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public CollectionRequest<Task> addDependentsForTask(String taskGid) throws IOException {
+            return addDependentsForTask(taskGid, null, false);
+        }
+        /**
+        * Add followers to a task
+        * Adds followers to a task. Returns an empty data block. Each task can be associated with zero or more followers in the system. Requests to add/remove followers, if successful, will return the complete updated task record, described above.
+            * @param taskGid The task to operate on. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> addFollowersForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks/{task_gid}/addFollowers".replace("{task_gid}", taskGid);
+
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public ItemRequest<JsonElement> addFollowersForTask(String taskGid) throws IOException {
+            return addFollowersForTask(taskGid, null, false);
+        }
+        /**
+        * Add a project to a task
+        * Adds the task to the specified project, in the optional location specified. If no location arguments are given, the task will be added to the end of the project.  &#x60;addProject&#x60; can also be used to reorder a task within a project or section that already contains it.  At most one of &#x60;insert_before&#x60;, &#x60;insert_after&#x60;, or &#x60;section&#x60; should be specified. Inserting into a section in an non-order-dependent way can be done by specifying section, otherwise, to insert within a section in a particular place, specify &#x60;insert_before&#x60; or &#x60;insert_after&#x60; and a task within the section to anchor the position of this task.  Returns an empty data block.
+            * @param taskGid The task to operate on. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> addProjectForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks/{task_gid}/addProject".replace("{task_gid}", taskGid);
+
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public ItemRequest<JsonElement> addProjectForTask(String taskGid) throws IOException {
+            return addProjectForTask(taskGid, null, false);
+        }
+        /**
+        * Add a tag to a task
+        * Adds a tag to a task. Returns an empty data block.
+            * @param taskGid The task to operate on. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> addTagForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks/{task_gid}/addTag".replace("{task_gid}", taskGid);
+
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public ItemRequest<JsonElement> addTagForTask(String taskGid) throws IOException {
+            return addTagForTask(taskGid, null, false);
+        }
+        /**
+        * Create a subtask
+        * Creates a new subtask and adds it to the parent task. Returns the full record for the newly created subtask.
+            * @param taskGid The task to operate on. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Task>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Task> createSubtaskForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks/{task_gid}/subtasks".replace("{task_gid}", taskGid);
+
+            ItemRequest<Task> req = new ItemRequest<Task>(this, Task.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public ItemRequest<Task> createSubtaskForTask(String taskGid) throws IOException {
+            return createSubtaskForTask(taskGid, null, false);
+        }
+        /**
+        * Create a task
+        * Creating a new task is as easy as POSTing to the &#x60;/tasks&#x60; endpoint with a data block containing the fields you’d like to set on the task. Any unspecified fields will take on default values.  Every task is required to be created in a specific workspace, and this workspace cannot be changed once set. The workspace need not be set explicitly if you specify &#x60;projects&#x60; or a &#x60;parent&#x60; task instead.
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Task>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Task> createTask(List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks";
+
+            ItemRequest<Task> req = new ItemRequest<Task>(this, Task.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public ItemRequest<Task> createTask() throws IOException {
+            return createTask(null, false);
+        }
+        /**
+        * Delete a task
+        * A specific, existing task can be deleted by making a DELETE request on the URL for that task. Deleted tasks go into the “trash” of the user making the delete request. Tasks can be recovered from the trash within a period of 30 days; afterward they are completely removed from the system.  Returns an empty data record.
+            * @param taskGid The task to operate on. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> deleteTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks/{task_gid}".replace("{task_gid}", taskGid);
+
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public ItemRequest<JsonElement> deleteTask(String taskGid) throws IOException {
+            return deleteTask(taskGid, null, false);
+        }
+        /**
+        * Duplicate a task
+        * Creates and returns a job that will asynchronously handle the duplication.
+            * @param taskGid The task to operate on. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Job>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Job> duplicateTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks/{task_gid}/duplicate".replace("{task_gid}", taskGid);
+
+            ItemRequest<Job> req = new ItemRequest<Job>(this, Job.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public ItemRequest<Job> duplicateTask(String taskGid) throws IOException {
+            return duplicateTask(taskGid, null, false);
+        }
+        /**
+        * Get dependencies from a task
+        * Returns the compact representations of all of the dependencies of a task.
+            * @param taskGid The task to operate on. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Task>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Task> getDependenciesForTask(String taskGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks/{task_gid}/dependencies".replace("{task_gid}", taskGid);
+
+            CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
+
+            return req;
+        }
+
+        public CollectionRequest<Task> getDependenciesForTask(String taskGid) throws IOException {
+            return getDependenciesForTask(taskGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Get dependents from a task
+        * Returns the compact representations of all of the dependents of a task.
+            * @param taskGid The task to operate on. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Task>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Task> getDependentsForTask(String taskGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks/{task_gid}/dependents".replace("{task_gid}", taskGid);
+
+            CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
+
+            return req;
+        }
+
+        public CollectionRequest<Task> getDependentsForTask(String taskGid) throws IOException {
+            return getDependentsForTask(taskGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Get subtasks from a task
+        * Returns a compact representation of all of the subtasks of a task.
+            * @param taskGid The task to operate on. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Task>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Task> getSubtasksForTask(String taskGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks/{task_gid}/subtasks".replace("{task_gid}", taskGid);
+
+            CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
+
+            return req;
+        }
+
+        public CollectionRequest<Task> getSubtasksForTask(String taskGid) throws IOException {
+            return getSubtasksForTask(taskGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Get a task
+        * Returns the complete task record for a single task.
+            * @param taskGid The task to operate on. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Task>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Task> getTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks/{task_gid}".replace("{task_gid}", taskGid);
+
+            ItemRequest<Task> req = new ItemRequest<Task>(this, Task.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public ItemRequest<Task> getTask(String taskGid) throws IOException {
+            return getTask(taskGid, null, false);
+        }
+        /**
+        * Get multiple tasks
+        * Returns the compact task records for some filtered set of tasks. Use one or more of the parameters provided to filter the tasks returned. You must specify a &#x60;project&#x60; or &#x60;tag&#x60; if you do not specify &#x60;assignee&#x60; and &#x60;workspace&#x60;.  For more complex task retrieval, use [workspaces/{workspace_gid}/tasks/search](#search-tasks-in-a-workspace).
+            * @param modifiedSince Only return tasks that have been modified since the given time.  *Note: A task is considered “modified” if any of its properties change, or associations between it and other objects are modified (e.g.  a task being added to a project). A task is not considered modified just because another object it is associated with (e.g. a subtask) is modified. Actions that count as modifying the task include assigning, renaming, completing, and adding stories.* (optional)
+            * @param completedSince Only return tasks that are either incomplete or that have been completed since this time. (optional)
+            * @param workspace The workspace to filter tasks on. *Note: If you specify &#x60;workspace&#x60;, you must also specify the &#x60;assignee&#x60; to filter on.* (optional)
+            * @param section The section to filter tasks on. *Note: Currently, this is only supported in board views.* (optional)
+            * @param project The project to filter tasks on. (optional)
+            * @param assignee The assignee to filter tasks on. *Note: If you specify &#x60;assignee&#x60;, you must also specify the &#x60;workspace&#x60; to filter on.* (optional)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Task>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Task> getTasks(OffsetDateTime modifiedSince, OffsetDateTime completedSince, String workspace, String section, String project, String assignee, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks";
+
+            CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset)
+                .query("assignee", assignee)
+                .query("project", project)
+                .query("section", section)
+                .query("workspace", workspace)
+                .query("completed_since", completedSince)
+                .query("modified_since", modifiedSince);
+
+            return req;
+        }
+
+        public CollectionRequest<Task> getTasks(OffsetDateTime modifiedSince, OffsetDateTime completedSince, String workspace, String section, String project, String assignee) throws IOException {
+            return getTasks(modifiedSince, completedSince, workspace, section, project, assignee, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Get tasks from a project
+        * Returns the compact task records for all tasks within the given project, ordered by their priority within the project. Tasks can exist in more than one project at a time.
+            * @param projectGid Globally unique identifier for the project. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Task>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Task> getTasksForProject(String projectGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/projects/{project_gid}/tasks".replace("{project_gid}", projectGid);
+
+            CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
+
+            return req;
+        }
+
+        public CollectionRequest<Task> getTasksForProject(String projectGid) throws IOException {
+            return getTasksForProject(projectGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Get tasks from a section
+        * *Board view only*: Returns the compact section records for all tasks within the given section.
+            * @param sectionGid The globally unique identifier for the section. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Task>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Task> getTasksForSection(String sectionGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/sections/{section_gid}/tasks".replace("{section_gid}", sectionGid);
+
+            CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
+
+            return req;
+        }
+
+        public CollectionRequest<Task> getTasksForSection(String sectionGid) throws IOException {
+            return getTasksForSection(sectionGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Get tasks from a tag
+        * Returns the compact task records for all tasks with the given tag. Tasks can have more than one tag at a time.
+            * @param tagGid Globally unique identifier for the tag. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Task>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Task> getTasksForTag(String tagGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tags/{tag_gid}/tasks".replace("{tag_gid}", tagGid);
+
+            CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
+
+            return req;
+        }
+
+        public CollectionRequest<Task> getTasksForTag(String tagGid) throws IOException {
+            return getTasksForTag(tagGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Get tasks from a user task list
+        * Returns the compact list of tasks in a user’s My Tasks list. The returned tasks will be in order within each assignee status group of &#x60;Inbox&#x60;, &#x60;Today&#x60;, and &#x60;Upcoming&#x60;. *Note: tasks in &#x60;Later&#x60; have a different ordering in the Asana web app than the other assignee status groups; this endpoint will still return them in list order in &#x60;Later&#x60; (differently than they show up in Asana, but the same order as in Asana’s mobile apps).* *Note: Access control is enforced for this endpoint as with all Asana API endpoints, meaning a user’s private tasks will be filtered out if the API-authenticated user does not have access to them.* *Note: Both complete and incomplete tasks are returned by default unless they are filtered out (for example, setting &#x60;completed_since&#x3D;now&#x60; will return only incomplete tasks, which is the default view for “My Tasks” in Asana.)*
+            * @param userTaskListGid Globally unique identifier for the user task list. (required)
+            * @param completedSince Only return tasks that are either incomplete or that have been completed since this time. Accepts a date-time string or the keyword *now*.  (optional)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Task>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Task> getTasksForUserTaskList(String userTaskListGid, String completedSince, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/user_task_lists/{user_task_list_gid}/tasks".replace("{user_task_list_gid}", userTaskListGid);
+
+            CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
+                .query("completed_since", completedSince)
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
+
+            return req;
+        }
+
+        public CollectionRequest<Task> getTasksForUserTaskList(String userTaskListGid, String completedSince) throws IOException {
+            return getTasksForUserTaskList(userTaskListGid, completedSince, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Unlink dependencies from a task
+        * Unlinks a set of dependencies from this task.
+            * @param taskGid The task to operate on. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Task>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Task> removeDependenciesForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks/{task_gid}/removeDependencies".replace("{task_gid}", taskGid);
+
+            CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public CollectionRequest<Task> removeDependenciesForTask(String taskGid) throws IOException {
+            return removeDependenciesForTask(taskGid, null, false);
+        }
+        /**
+        * Unlink dependents from a task
+        * Unlinks a set of dependents from this task.
+            * @param taskGid The task to operate on. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Task>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Task> removeDependentsForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks/{task_gid}/removeDependents".replace("{task_gid}", taskGid);
+
+            CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public CollectionRequest<Task> removeDependentsForTask(String taskGid) throws IOException {
+            return removeDependentsForTask(taskGid, null, false);
+        }
+        /**
+        * Remove followers from a task
+        * Removes each of the specified followers from the task if they are following. Returns the complete, updated record for the affected task.
+            * @param taskGid The task to operate on. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> removeFollowerForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks/{task_gid}/removeFollowers".replace("{task_gid}", taskGid);
+
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public ItemRequest<JsonElement> removeFollowerForTask(String taskGid) throws IOException {
+            return removeFollowerForTask(taskGid, null, false);
+        }
+        /**
+        * Remove a project from a task
+        * Removes the task from the specified project. The task will still exist in the system, but it will not be in the project anymore.  Returns an empty data block.
+            * @param taskGid The task to operate on. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> removeProjectForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks/{task_gid}/removeProject".replace("{task_gid}", taskGid);
+
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public ItemRequest<JsonElement> removeProjectForTask(String taskGid) throws IOException {
+            return removeProjectForTask(taskGid, null, false);
+        }
+        /**
+        * Remove a tag from a task
+        * Removes a tag from a task. Returns an empty data block.
+            * @param taskGid The task to operate on. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> removeTagForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks/{task_gid}/removeTag".replace("{task_gid}", taskGid);
+
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public ItemRequest<JsonElement> removeTagForTask(String taskGid) throws IOException {
+            return removeTagForTask(taskGid, null, false);
+        }
+        /**
+        * Search tasks in a workspace
+        * To mirror the functionality of the Asana web app&#x27;s advanced search feature, the Asana API has a task search endpoint that allows you to build complex filters to find and retrieve the exact data you need. #### Premium access Like the Asana web product&#x27;s advance search feature, this search endpoint will only be available to premium Asana users. A user is premium if any of the following is true:  - The workspace in which the search is being performed is a premium workspace - The user is a member of a premium team inside the workspace  Even if a user is only a member of a premium team inside a non-premium workspace, search will allow them to find data anywhere in the workspace, not just inside the premium team. Making a search request using credentials of a non-premium user will result in a &#x60;402 Payment Required&#x60; error. #### Pagination Search results are not stable; repeating the same query multiple times may return the data in a different order, even if the data do not change. Because of this, the traditional [pagination](https://developers.asana.com/docs/#pagination) available elsewhere in the Asana API is not available here. However, you can paginate manually by sorting the search results by their creation time and then modifying each subsequent query to exclude data you have already seen. Page sizes are limited to a maximum of 100 items, and can be specified by the &#x60;limit&#x60; query parameter. #### Eventual consistency Changes in Asana (regardless of whether they’re made though the web product or the API) are forwarded to our search infrastructure to be indexed. This process can take between 10 and 60 seconds to complete under normal operation, and longer during some production incidents. Making a change to a task that would alter its presence in a particular search query will not be reflected immediately. This is also true of the advanced search feature in the web product. #### Rate limits You may receive a &#x60;429 Too Many Requests&#x60; response if you hit any of our [rate limits](https://developers.asana.com/docs/#rate-limits). #### Custom field parameters | Parameter name | Custom field type | Accepted type | |---|---|---| | custom_fields.{gid}.is_set | All | Boolean | | custom_fields.{gid}.value | Text | String | | custom_fields.{gid}.value | Number | Number | | custom_fields.{gid}.value | Enum | Enum option ID | | custom_fields.{gid}.starts_with | Text only | String | | custom_fields.{gid}.ends_with | Text only | String | | custom_fields.{gid}.contains | Text only | String | | custom_fields.{gid}.less_than | Number only | Number | | custom_fields.{gid}.greater_than | Number only | Number |   For example, if the gid of the custom field is 12345, these query parameter to find tasks where it is set would be &#x60;custom_fields.12345.is_set&#x3D;true&#x60;. To match an exact value for an enum custom field, use the gid of the desired enum option and not the name of the enum option: &#x60;custom_fields.12345.value&#x3D;67890&#x60;.  Searching for multiple exact matches of a custom field is not supported.
+            * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+            * @param sortAscending Default &#x60;false&#x60; (optional)
+            * @param sortBy One of &#x60;due_date&#x60;, &#x60;created_at&#x60;, &#x60;completed_at&#x60;, &#x60;likes&#x60;, or &#x60;modified_at&#x60;, defaults to &#x60;modified_at&#x60; (optional)
+            * @param isSubtask Filter to subtasks (optional)
+            * @param completed Filter to completed tasks (optional)
+            * @param hasAttachment Filter to tasks with attachments (optional)
+            * @param isBlocked Filter to tasks with incomplete dependencies (optional)
+            * @param isBlocking Filter to incomplete tasks with dependents (optional)
+            * @param modifiedAtAfter ISO 8601 datetime string (optional)
+            * @param modifiedAtBefore ISO 8601 datetime string (optional)
+            * @param dueOnBefore ISO 8601 date string (optional)
+            * @param modifiedOn ISO 8601 date string or &#x60;null&#x60; (optional)
+            * @param modifiedOnAfter ISO 8601 date string (optional)
+            * @param modifiedOnBefore ISO 8601 date string (optional)
+            * @param completedAtAfter ISO 8601 datetime string (optional)
+            * @param completedAtBefore ISO 8601 datetime string (optional)
+            * @param completedOn ISO 8601 date string or &#x60;null&#x60; (optional)
+            * @param completedOnAfter ISO 8601 date string (optional)
+            * @param completedOnBefore ISO 8601 date string (optional)
+            * @param createdAtAfter ISO 8601 datetime string (optional)
+            * @param commentedOnByNot Comma-separated list of user identifiers (optional)
+            * @param createdAtBefore ISO 8601 datetime string (optional)
+            * @param createdOn ISO 8601 date string or &#x60;null&#x60; (optional)
+            * @param createdOnAfter ISO 8601 date string (optional)
+            * @param createdOnBefore ISO 8601 date string (optional)
+            * @param startOn ISO 8601 date string or &#x60;null&#x60; (optional)
+            * @param startOnAfter ISO 8601 date string (optional)
+            * @param startOnBefore ISO 8601 date string (optional)
+            * @param dueAtAfter ISO 8601 datetime string (optional)
+            * @param dueAtBefore ISO 8601 datetime string (optional)
+            * @param dueOn ISO 8601 date string or &#x60;null&#x60; (optional)
+            * @param commentedOnByAny Comma-separated list of user identifiers (optional)
+            * @param dueOnAfter ISO 8601 date string (optional)
+            * @param likedByNot Comma-separated list of user identifiers (optional)
+            * @param likedByAny Comma-separated list of user identifiers (optional)
+            * @param assignedByNot Comma-separated list of user identifiers (optional)
+            * @param assignedByAny Comma-separated list of user identifiers (optional)
+            * @param createdByNot Comma-separated list of user identifiers (optional)
+            * @param createdByAny Comma-separated list of user identifiers (optional)
+            * @param followersNot Comma-separated list of user identifiers (optional)
+            * @param followersAny Comma-separated list of user identifiers (optional)
+            * @param teamsAny Comma-separated list of team IDs (optional)
+            * @param tagsAll Comma-separated list of tag IDs (optional)
+            * @param tagsNot Comma-separated list of tag IDs (optional)
+            * @param tagsAny Comma-separated list of tag IDs (optional)
+            * @param sectionsAll Comma-separated list of section or column IDs (optional)
+            * @param sectionsNot Comma-separated list of section or column IDs (optional)
+            * @param sectionsAny Comma-separated list of section or column IDs (optional)
+            * @param projectsAll Comma-separated list of project IDs (optional)
+            * @param projectsNot Comma-separated list of project IDs (optional)
+            * @param projectsAny Comma-separated list of project IDs (optional)
+            * @param assigneeStatus One of &#x60;inbox&#x60;, &#x60;today&#x60;, &#x60;upcoming&#x60;, or &#x60;later&#x60; (optional)
+            * @param assigneeNot Comma-separated list of user identifiers (optional)
+            * @param assigneeAny Comma-separated list of user identifiers (optional)
+            * @param resourceSubtype Filters results by the task&#x27;s resource_subtype (optional)
+            * @param text Performs full-text search on both task name and description (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Task>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Task> searchTasksForWorkspace(String workspaceGid, Boolean sortAscending, String sortBy, Boolean isSubtask, Boolean completed, Boolean hasAttachment, Boolean isBlocked, Boolean isBlocking, OffsetDateTime modifiedAtAfter, OffsetDateTime modifiedAtBefore, LocalDate dueOnBefore, LocalDate modifiedOn, LocalDate modifiedOnAfter, LocalDate modifiedOnBefore, OffsetDateTime completedAtAfter, OffsetDateTime completedAtBefore, LocalDate completedOn, LocalDate completedOnAfter, LocalDate completedOnBefore, OffsetDateTime createdAtAfter, String commentedOnByNot, OffsetDateTime createdAtBefore, LocalDate createdOn, LocalDate createdOnAfter, LocalDate createdOnBefore, LocalDate startOn, LocalDate startOnAfter, LocalDate startOnBefore, OffsetDateTime dueAtAfter, OffsetDateTime dueAtBefore, LocalDate dueOn, String commentedOnByAny, LocalDate dueOnAfter, String likedByNot, String likedByAny, String assignedByNot, String assignedByAny, String createdByNot, String createdByAny, String followersNot, String followersAny, String teamsAny, String tagsAll, String tagsNot, String tagsAny, String sectionsAll, String sectionsNot, String sectionsAny, String projectsAll, String projectsNot, String projectsAny, String assigneeStatus, String assigneeNot, String assigneeAny, String resourceSubtype, String text, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/workspaces/{workspace_gid}/tasks/search".replace("{workspace_gid}", workspaceGid);
+
+            CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("text", text)
+                .query("resource_subtype", resourceSubtype)
+                .query("assignee.any", assigneeAny)
+                .query("assignee.not", assigneeNot)
+                .query("assignee_status", assigneeStatus)
+                .query("projects.any", projectsAny)
+                .query("projects.not", projectsNot)
+                .query("projects.all", projectsAll)
+                .query("sections.any", sectionsAny)
+                .query("sections.not", sectionsNot)
+                .query("sections.all", sectionsAll)
+                .query("tags.any", tagsAny)
+                .query("tags.not", tagsNot)
+                .query("tags.all", tagsAll)
+                .query("teams.any", teamsAny)
+                .query("followers.any", followersAny)
+                .query("followers.not", followersNot)
+                .query("created_by.any", createdByAny)
+                .query("created_by.not", createdByNot)
+                .query("assigned_by.any", assignedByAny)
+                .query("assigned_by.not", assignedByNot)
+                .query("liked_by.any", likedByAny)
+                .query("liked_by.not", likedByNot)
+                .query("commented_on_by.any", commentedOnByAny)
+                .query("commented_on_by.not", commentedOnByNot)
+                .query("due_on.before", dueOnBefore)
+                .query("due_on.after", dueOnAfter)
+                .query("due_on", dueOn)
+                .query("due_at.before", dueAtBefore)
+                .query("due_at.after", dueAtAfter)
+                .query("start_on.before", startOnBefore)
+                .query("start_on.after", startOnAfter)
+                .query("start_on", startOn)
+                .query("created_on.before", createdOnBefore)
+                .query("created_on.after", createdOnAfter)
+                .query("created_on", createdOn)
+                .query("created_at.before", createdAtBefore)
+                .query("created_at.after", createdAtAfter)
+                .query("completed_on.before", completedOnBefore)
+                .query("completed_on.after", completedOnAfter)
+                .query("completed_on", completedOn)
+                .query("completed_at.before", completedAtBefore)
+                .query("completed_at.after", completedAtAfter)
+                .query("modified_on.before", modifiedOnBefore)
+                .query("modified_on.after", modifiedOnAfter)
+                .query("modified_on", modifiedOn)
+                .query("modified_at.before", modifiedAtBefore)
+                .query("modified_at.after", modifiedAtAfter)
+                .query("is_blocking", isBlocking)
+                .query("is_blocked", isBlocked)
+                .query("has_attachment", hasAttachment)
+                .query("completed", completed)
+                .query("is_subtask", isSubtask)
+                .query("sort_by", sortBy)
+                .query("sort_ascending", sortAscending);
+
+            return req;
+        }
+
+        public CollectionRequest<Task> searchTasksForWorkspace(String workspaceGid, Boolean sortAscending, String sortBy, Boolean isSubtask, Boolean completed, Boolean hasAttachment, Boolean isBlocked, Boolean isBlocking, OffsetDateTime modifiedAtAfter, OffsetDateTime modifiedAtBefore, LocalDate dueOnBefore, LocalDate modifiedOn, LocalDate modifiedOnAfter, LocalDate modifiedOnBefore, OffsetDateTime completedAtAfter, OffsetDateTime completedAtBefore, LocalDate completedOn, LocalDate completedOnAfter, LocalDate completedOnBefore, OffsetDateTime createdAtAfter, String commentedOnByNot, OffsetDateTime createdAtBefore, LocalDate createdOn, LocalDate createdOnAfter, LocalDate createdOnBefore, LocalDate startOn, LocalDate startOnAfter, LocalDate startOnBefore, OffsetDateTime dueAtAfter, OffsetDateTime dueAtBefore, LocalDate dueOn, String commentedOnByAny, LocalDate dueOnAfter, String likedByNot, String likedByAny, String assignedByNot, String assignedByAny, String createdByNot, String createdByAny, String followersNot, String followersAny, String teamsAny, String tagsAll, String tagsNot, String tagsAny, String sectionsAll, String sectionsNot, String sectionsAny, String projectsAll, String projectsNot, String projectsAny, String assigneeStatus, String assigneeNot, String assigneeAny, String resourceSubtype, String text) throws IOException {
+            return searchTasksForWorkspace(workspaceGid, sortAscending, sortBy, isSubtask, completed, hasAttachment, isBlocked, isBlocking, modifiedAtAfter, modifiedAtBefore, dueOnBefore, modifiedOn, modifiedOnAfter, modifiedOnBefore, completedAtAfter, completedAtBefore, completedOn, completedOnAfter, completedOnBefore, createdAtAfter, commentedOnByNot, createdAtBefore, createdOn, createdOnAfter, createdOnBefore, startOn, startOnAfter, startOnBefore, dueAtAfter, dueAtBefore, dueOn, commentedOnByAny, dueOnAfter, likedByNot, likedByAny, assignedByNot, assignedByAny, createdByNot, createdByAny, followersNot, followersAny, teamsAny, tagsAll, tagsNot, tagsAny, sectionsAll, sectionsNot, sectionsAny, projectsAll, projectsNot, projectsAny, assigneeStatus, assigneeNot, assigneeAny, resourceSubtype, text, null, false);
+        }
+        /**
+        * Set the parent of a task
+        * parent, or no parent task at all. Returns an empty data block. When using &#x60;insert_before&#x60; and &#x60;insert_after&#x60;, at most one of those two options can be specified, and they must already be subtasks of the parent.
+            * @param taskGid The task to operate on. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Task>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Task> setParentForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks/{task_gid}/setParent".replace("{task_gid}", taskGid);
+
+            ItemRequest<Task> req = new ItemRequest<Task>(this, Task.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public ItemRequest<Task> setParentForTask(String taskGid) throws IOException {
+            return setParentForTask(taskGid, null, false);
+        }
+        /**
+        * Update a task
+        * A specific, existing task can be updated by making a PUT request on the URL for that task. Only the fields provided in the &#x60;data&#x60; block will be updated; any unspecified fields will remain unchanged.  When using this method, it is best to specify only those fields you wish to change, or else you may overwrite changes made by another user since you last retrieved the task.  Returns the complete updated task record.
+            * @param taskGid The task to operate on. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Task>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Task> updateTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/tasks/{task_gid}".replace("{task_gid}", taskGid);
+
+            ItemRequest<Task> req = new ItemRequest<Task>(this, Task.class, path, "PUT")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
+
+            return req;
+        }
+
+        public ItemRequest<Task> updateTask(String taskGid) throws IOException {
+            return updateTask(taskGid, null, false);
+        }
     }

--- a/src/main/java/com/asana/resources/gen/TasksBase.java
+++ b/src/main/java/com/asana/resources/gen/TasksBase.java
@@ -1,483 +1,771 @@
 package com.asana.resources.gen;
 
 import com.asana.Client;
-import com.asana.models.Job;
 import com.asana.resources.Resource;
-import com.asana.models.Task;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
+import com.asana.models.Task;
+import com.google.gson.JsonElement;
 
-/**
- * The _task_ is the basic object around which many operations in Asana are
- * centered. In the Asana application, multiple tasks populate the middle pane
- * according to some view parameters, and the set of selected tasks determines
- * the more detailed information presented in the details pane.
- */
-public class TasksBase extends Resource {
+import java.io.IOException;
+import java.util.List;
+
+    public class TasksBase extends Resource {
     /**
-     * @param client Parent client instance
-     */
-    public TasksBase(Client client) {
-        super(client);
+    * @param client Parent client instance
+    */
+    public TasksBase(Client client) { super(client); }
+
+            /**
+            * Set dependencies for a task
+            * Marks a set of tasks as dependencies of this task, if they are not already dependencies. *A task can have at most 15 dependencies*.
+                * @param taskGid The task to operate on. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Task>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Task> addDependenciesForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tasks/{task_gid}/addDependencies".replace("{task_gid}", taskGid);
+
+                CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public CollectionRequest<Task> addDependenciesForTask(String taskGid) throws IOException {
+                return addDependenciesForTask(taskGid, null, false);
+            }
+
+            /**
+            * Set dependents for a task
+            * Marks a set of tasks as dependents of this task, if they are not already dependents. *A task can have at most 30 dependents*.
+                * @param taskGid The task to operate on. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Task>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Task> addDependentsForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tasks/{task_gid}/addDependents".replace("{task_gid}", taskGid);
+
+                CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public CollectionRequest<Task> addDependentsForTask(String taskGid) throws IOException {
+                return addDependentsForTask(taskGid, null, false);
+            }
+
+            /**
+            * Add followers to a task
+            * Adds followers to a task. Returns an empty data block. Each task can be associated with zero or more followers in the system. Requests to add/remove followers, if successful, will return the complete updated task record, described above.
+                * @param taskGid The task to operate on. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> addFollowersForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tasks/{task_gid}/addFollowers".replace("{task_gid}", taskGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> addFollowersForTask(String taskGid) throws IOException {
+                return addFollowersForTask(taskGid, null, false);
+            }
+
+            /**
+            * Add a project to a task
+            * Adds the task to the specified project, in the optional location specified. If no location arguments are given, the task will be added to the end of the project.  &#x60;addProject&#x60; can also be used to reorder a task within a project or section that already contains it.  At most one of &#x60;insert_before&#x60;, &#x60;insert_after&#x60;, or &#x60;section&#x60; should be specified. Inserting into a section in an non-order-dependent way can be done by specifying section, otherwise, to insert within a section in a particular place, specify &#x60;insert_before&#x60; or &#x60;insert_after&#x60; and a task within the section to anchor the position of this task.  Returns an empty data block.
+                * @param taskGid The task to operate on. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> addProjectForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tasks/{task_gid}/addProject".replace("{task_gid}", taskGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> addProjectForTask(String taskGid) throws IOException {
+                return addProjectForTask(taskGid, null, false);
+            }
+
+            /**
+            * Add a tag to a task
+            * Adds a tag to a task. Returns an empty data block.
+                * @param taskGid The task to operate on. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> addTagForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tasks/{task_gid}/addTag".replace("{task_gid}", taskGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> addTagForTask(String taskGid) throws IOException {
+                return addTagForTask(taskGid, null, false);
+            }
+
+            /**
+            * Create a subtask
+            * Creates a new subtask and adds it to the parent task. Returns the full record for the newly created subtask.
+                * @param taskGid The task to operate on. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Task>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Task> createSubtaskForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tasks/{task_gid}/subtasks".replace("{task_gid}", taskGid);
+
+                ItemRequest<Task> req = new ItemRequest<Task>(this, Task.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<Task> createSubtaskForTask(String taskGid) throws IOException {
+                return createSubtaskForTask(taskGid, null, false);
+            }
+
+            /**
+            * Create a task
+            * Creating a new task is as easy as POSTing to the &#x60;/tasks&#x60; endpoint with a data block containing the fields you’d like to set on the task. Any unspecified fields will take on default values.  Every task is required to be created in a specific workspace, and this workspace cannot be changed once set. The workspace need not be set explicitly if you specify &#x60;projects&#x60; or a &#x60;parent&#x60; task instead.
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Task>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Task> createTask(List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tasks";
+
+                ItemRequest<Task> req = new ItemRequest<Task>(this, Task.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<Task> createTask() throws IOException {
+                return createTask(null, false);
+            }
+
+            /**
+            * Delete a task
+            * A specific, existing task can be deleted by making a DELETE request on the URL for that task. Deleted tasks go into the “trash” of the user making the delete request. Tasks can be recovered from the trash within a period of 30 days; afterward they are completely removed from the system.  Returns an empty data record.
+                * @param taskGid The task to operate on. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> deleteTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tasks/{task_gid}".replace("{task_gid}", taskGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> deleteTask(String taskGid) throws IOException {
+                return deleteTask(taskGid, null, false);
+            }
+
+            /**
+            * Duplicate a task
+            * Creates and returns a job that will asynchronously handle the duplication.
+                * @param taskGid The task to operate on. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Job>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Job> duplicateTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tasks/{task_gid}/duplicate".replace("{task_gid}", taskGid);
+
+                ItemRequest<Job> req = new ItemRequest<Job>(this, Job.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<Job> duplicateTask(String taskGid) throws IOException {
+                return duplicateTask(taskGid, null, false);
+            }
+
+            /**
+            * Get dependencies from a task
+            * Returns the compact representations of all of the dependencies of a task.
+                * @param taskGid The task to operate on. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Task>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Task> getDependenciesForTask(String taskGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tasks/{task_gid}/dependencies".replace("{task_gid}", taskGid);
+
+                CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public CollectionRequest<Task> getDependenciesForTask(String taskGid) throws IOException {
+                return getDependenciesForTask(taskGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Get dependents from a task
+            * Returns the compact representations of all of the dependents of a task.
+                * @param taskGid The task to operate on. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Task>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Task> getDependentsForTask(String taskGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tasks/{task_gid}/dependents".replace("{task_gid}", taskGid);
+
+                CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public CollectionRequest<Task> getDependentsForTask(String taskGid) throws IOException {
+                return getDependentsForTask(taskGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Get subtasks from a task
+            * Returns a compact representation of all of the subtasks of a task.
+                * @param taskGid The task to operate on. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Task>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Task> getSubtasksForTask(String taskGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tasks/{task_gid}/subtasks".replace("{task_gid}", taskGid);
+
+                CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public CollectionRequest<Task> getSubtasksForTask(String taskGid) throws IOException {
+                return getSubtasksForTask(taskGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Get a task
+            * Returns the complete task record for a single task.
+                * @param taskGid The task to operate on. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Task>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Task> getTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tasks/{task_gid}".replace("{task_gid}", taskGid);
+
+                ItemRequest<Task> req = new ItemRequest<Task>(this, Task.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<Task> getTask(String taskGid) throws IOException {
+                return getTask(taskGid, null, false);
+            }
+
+            /**
+            * Get multiple tasks
+            * Returns the compact task records for some filtered set of tasks. Use one or more of the parameters provided to filter the tasks returned. You must specify a &#x60;project&#x60; or &#x60;tag&#x60; if you do not specify &#x60;assignee&#x60; and &#x60;workspace&#x60;.  For more complex task retrieval, use [workspaces/{workspace_gid}/tasks/search](#search-tasks-in-a-workspace).
+                * @param modifiedSince Only return tasks that have been modified since the given time.  *Note: A task is considered “modified” if any of its properties change, or associations between it and other objects are modified (e.g.  a task being added to a project). A task is not considered modified just because another object it is associated with (e.g. a subtask) is modified. Actions that count as modifying the task include assigning, renaming, completing, and adding stories.* (optional)
+                * @param completedSince Only return tasks that are either incomplete or that have been completed since this time. (optional)
+                * @param workspace The workspace to filter tasks on. *Note: If you specify &#x60;workspace&#x60;, you must also specify the &#x60;assignee&#x60; to filter on.* (optional)
+                * @param section The section to filter tasks on. *Note: Currently, this is only supported in board views.* (optional)
+                * @param project The project to filter tasks on. (optional)
+                * @param assignee The assignee to filter tasks on. *Note: If you specify &#x60;assignee&#x60;, you must also specify the &#x60;workspace&#x60; to filter on.* (optional)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Task>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Task> getTasks(OffsetDateTime modifiedSince, OffsetDateTime completedSince, String workspace, String section, String project, String assignee, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tasks";
+
+                CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset)
+                    .query("assignee", assignee)
+                    .query("project", project)
+                    .query("section", section)
+                    .query("workspace", workspace)
+                    .query("completed_since", completedSince)
+                    .query("modified_since", modifiedSince);
+
+                return req;
+            }
+
+            public CollectionRequest<Task> getTasks(OffsetDateTime modifiedSince, OffsetDateTime completedSince, String workspace, String section, String project, String assignee) throws IOException {
+                return getTasks(modifiedSince, completedSince, workspace, section, project, assignee, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Get tasks from a project
+            * Returns the compact task records for all tasks within the given project, ordered by their priority within the project. Tasks can exist in more than one project at a time.
+                * @param projectGid Globally unique identifier for the project. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Task>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Task> getTasksForProject(String projectGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/projects/{project_gid}/tasks".replace("{project_gid}", projectGid);
+
+                CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public CollectionRequest<Task> getTasksForProject(String projectGid) throws IOException {
+                return getTasksForProject(projectGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Get tasks from a section
+            * *Board view only*: Returns the compact section records for all tasks within the given section.
+                * @param sectionGid The globally unique identifier for the section. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Task>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Task> getTasksForSection(String sectionGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/sections/{section_gid}/tasks".replace("{section_gid}", sectionGid);
+
+                CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public CollectionRequest<Task> getTasksForSection(String sectionGid) throws IOException {
+                return getTasksForSection(sectionGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Get tasks from a tag
+            * Returns the compact task records for all tasks with the given tag. Tasks can have more than one tag at a time.
+                * @param tagGid Globally unique identifier for the tag. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Task>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Task> getTasksForTag(String tagGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tags/{tag_gid}/tasks".replace("{tag_gid}", tagGid);
+
+                CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public CollectionRequest<Task> getTasksForTag(String tagGid) throws IOException {
+                return getTasksForTag(tagGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Get tasks from a user task list
+            * Returns the compact list of tasks in a user’s My Tasks list. The returned tasks will be in order within each assignee status group of &#x60;Inbox&#x60;, &#x60;Today&#x60;, and &#x60;Upcoming&#x60;. *Note: tasks in &#x60;Later&#x60; have a different ordering in the Asana web app than the other assignee status groups; this endpoint will still return them in list order in &#x60;Later&#x60; (differently than they show up in Asana, but the same order as in Asana’s mobile apps).* *Note: Access control is enforced for this endpoint as with all Asana API endpoints, meaning a user’s private tasks will be filtered out if the API-authenticated user does not have access to them.* *Note: Both complete and incomplete tasks are returned by default unless they are filtered out (for example, setting &#x60;completed_since&#x3D;now&#x60; will return only incomplete tasks, which is the default view for “My Tasks” in Asana.)*
+                * @param userTaskListGid Globally unique identifier for the user task list. (required)
+                * @param completedSince Only return tasks that are either incomplete or that have been completed since this time. Accepts a date-time string or the keyword *now*.  (optional)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Task>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Task> getTasksForUserTaskList(String userTaskListGid, String completedSince, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/user_task_lists/{user_task_list_gid}/tasks".replace("{user_task_list_gid}", userTaskListGid);
+
+                CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
+                    .query("completed_since", completedSince)
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public CollectionRequest<Task> getTasksForUserTaskList(String userTaskListGid, String completedSince) throws IOException {
+                return getTasksForUserTaskList(userTaskListGid, completedSince, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Unlink dependencies from a task
+            * Unlinks a set of dependencies from this task.
+                * @param taskGid The task to operate on. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Task>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Task> removeDependenciesForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tasks/{task_gid}/removeDependencies".replace("{task_gid}", taskGid);
+
+                CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public CollectionRequest<Task> removeDependenciesForTask(String taskGid) throws IOException {
+                return removeDependenciesForTask(taskGid, null, false);
+            }
+
+            /**
+            * Unlink dependents from a task
+            * Unlinks a set of dependents from this task.
+                * @param taskGid The task to operate on. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Task>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Task> removeDependentsForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tasks/{task_gid}/removeDependents".replace("{task_gid}", taskGid);
+
+                CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public CollectionRequest<Task> removeDependentsForTask(String taskGid) throws IOException {
+                return removeDependentsForTask(taskGid, null, false);
+            }
+
+            /**
+            * Remove followers from a task
+            * Removes each of the specified followers from the task if they are following. Returns the complete, updated record for the affected task.
+                * @param taskGid The task to operate on. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> removeFollowerForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tasks/{task_gid}/removeFollowers".replace("{task_gid}", taskGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> removeFollowerForTask(String taskGid) throws IOException {
+                return removeFollowerForTask(taskGid, null, false);
+            }
+
+            /**
+            * Remove a project from a task
+            * Removes the task from the specified project. The task will still exist in the system, but it will not be in the project anymore.  Returns an empty data block.
+                * @param taskGid The task to operate on. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> removeProjectForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tasks/{task_gid}/removeProject".replace("{task_gid}", taskGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> removeProjectForTask(String taskGid) throws IOException {
+                return removeProjectForTask(taskGid, null, false);
+            }
+
+            /**
+            * Remove a tag from a task
+            * Removes a tag from a task. Returns an empty data block.
+                * @param taskGid The task to operate on. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> removeTagForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tasks/{task_gid}/removeTag".replace("{task_gid}", taskGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> removeTagForTask(String taskGid) throws IOException {
+                return removeTagForTask(taskGid, null, false);
+            }
+
+            /**
+            * Search tasks in a workspace
+            * To mirror the functionality of the Asana web app&#x27;s advanced search feature, the Asana API has a task search endpoint that allows you to build complex filters to find and retrieve the exact data you need. #### Premium access Like the Asana web product&#x27;s advance search feature, this search endpoint will only be available to premium Asana users. A user is premium if any of the following is true:  - The workspace in which the search is being performed is a premium workspace - The user is a member of a premium team inside the workspace  Even if a user is only a member of a premium team inside a non-premium workspace, search will allow them to find data anywhere in the workspace, not just inside the premium team. Making a search request using credentials of a non-premium user will result in a &#x60;402 Payment Required&#x60; error. #### Pagination Search results are not stable; repeating the same query multiple times may return the data in a different order, even if the data do not change. Because of this, the traditional [pagination](https://developers.asana.com/docs/#pagination) available elsewhere in the Asana API is not available here. However, you can paginate manually by sorting the search results by their creation time and then modifying each subsequent query to exclude data you have already seen. Page sizes are limited to a maximum of 100 items, and can be specified by the &#x60;limit&#x60; query parameter. #### Eventual consistency Changes in Asana (regardless of whether they’re made though the web product or the API) are forwarded to our search infrastructure to be indexed. This process can take between 10 and 60 seconds to complete under normal operation, and longer during some production incidents. Making a change to a task that would alter its presence in a particular search query will not be reflected immediately. This is also true of the advanced search feature in the web product. #### Rate limits You may receive a &#x60;429 Too Many Requests&#x60; response if you hit any of our [rate limits](https://developers.asana.com/docs/#rate-limits). #### Custom field parameters | Parameter name | Custom field type | Accepted type | |---|---|---| | custom_fields.{gid}.is_set | All | Boolean | | custom_fields.{gid}.value | Text | String | | custom_fields.{gid}.value | Number | Number | | custom_fields.{gid}.value | Enum | Enum option ID | | custom_fields.{gid}.starts_with | Text only | String | | custom_fields.{gid}.ends_with | Text only | String | | custom_fields.{gid}.contains | Text only | String | | custom_fields.{gid}.less_than | Number only | Number | | custom_fields.{gid}.greater_than | Number only | Number |   For example, if the gid of the custom field is 12345, these query parameter to find tasks where it is set would be &#x60;custom_fields.12345.is_set&#x3D;true&#x60;. To match an exact value for an enum custom field, use the gid of the desired enum option and not the name of the enum option: &#x60;custom_fields.12345.value&#x3D;67890&#x60;.  Searching for multiple exact matches of a custom field is not supported.
+                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+                * @param sortAscending Default &#x60;false&#x60; (optional)
+                * @param sortBy One of &#x60;due_date&#x60;, &#x60;created_at&#x60;, &#x60;completed_at&#x60;, &#x60;likes&#x60;, or &#x60;modified_at&#x60;, defaults to &#x60;modified_at&#x60; (optional)
+                * @param isSubtask Filter to subtasks (optional)
+                * @param completed Filter to completed tasks (optional)
+                * @param hasAttachment Filter to tasks with attachments (optional)
+                * @param isBlocked Filter to tasks with incomplete dependencies (optional)
+                * @param isBlocking Filter to incomplete tasks with dependents (optional)
+                * @param modifiedAtAfter ISO 8601 datetime string (optional)
+                * @param modifiedAtBefore ISO 8601 datetime string (optional)
+                * @param dueOnBefore ISO 8601 date string (optional)
+                * @param modifiedOn ISO 8601 date string or &#x60;null&#x60; (optional)
+                * @param modifiedOnAfter ISO 8601 date string (optional)
+                * @param modifiedOnBefore ISO 8601 date string (optional)
+                * @param completedAtAfter ISO 8601 datetime string (optional)
+                * @param completedAtBefore ISO 8601 datetime string (optional)
+                * @param completedOn ISO 8601 date string or &#x60;null&#x60; (optional)
+                * @param completedOnAfter ISO 8601 date string (optional)
+                * @param completedOnBefore ISO 8601 date string (optional)
+                * @param createdAtAfter ISO 8601 datetime string (optional)
+                * @param commentedOnByNot Comma-separated list of user identifiers (optional)
+                * @param createdAtBefore ISO 8601 datetime string (optional)
+                * @param createdOn ISO 8601 date string or &#x60;null&#x60; (optional)
+                * @param createdOnAfter ISO 8601 date string (optional)
+                * @param createdOnBefore ISO 8601 date string (optional)
+                * @param startOn ISO 8601 date string or &#x60;null&#x60; (optional)
+                * @param startOnAfter ISO 8601 date string (optional)
+                * @param startOnBefore ISO 8601 date string (optional)
+                * @param dueAtAfter ISO 8601 datetime string (optional)
+                * @param dueAtBefore ISO 8601 datetime string (optional)
+                * @param dueOn ISO 8601 date string or &#x60;null&#x60; (optional)
+                * @param commentedOnByAny Comma-separated list of user identifiers (optional)
+                * @param dueOnAfter ISO 8601 date string (optional)
+                * @param likedByNot Comma-separated list of user identifiers (optional)
+                * @param likedByAny Comma-separated list of user identifiers (optional)
+                * @param assignedByNot Comma-separated list of user identifiers (optional)
+                * @param assignedByAny Comma-separated list of user identifiers (optional)
+                * @param createdByNot Comma-separated list of user identifiers (optional)
+                * @param createdByAny Comma-separated list of user identifiers (optional)
+                * @param followersNot Comma-separated list of user identifiers (optional)
+                * @param followersAny Comma-separated list of user identifiers (optional)
+                * @param teamsAny Comma-separated list of team IDs (optional)
+                * @param tagsAll Comma-separated list of tag IDs (optional)
+                * @param tagsNot Comma-separated list of tag IDs (optional)
+                * @param tagsAny Comma-separated list of tag IDs (optional)
+                * @param sectionsAll Comma-separated list of section or column IDs (optional)
+                * @param sectionsNot Comma-separated list of section or column IDs (optional)
+                * @param sectionsAny Comma-separated list of section or column IDs (optional)
+                * @param projectsAll Comma-separated list of project IDs (optional)
+                * @param projectsNot Comma-separated list of project IDs (optional)
+                * @param projectsAny Comma-separated list of project IDs (optional)
+                * @param assigneeStatus One of &#x60;inbox&#x60;, &#x60;today&#x60;, &#x60;upcoming&#x60;, or &#x60;later&#x60; (optional)
+                * @param assigneeNot Comma-separated list of user identifiers (optional)
+                * @param assigneeAny Comma-separated list of user identifiers (optional)
+                * @param resourceSubtype Filters results by the task&#x27;s resource_subtype (optional)
+                * @param text Performs full-text search on both task name and description (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Task>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Task> searchTasksForWorkspace(String workspaceGid, Boolean sortAscending, String sortBy, Boolean isSubtask, Boolean completed, Boolean hasAttachment, Boolean isBlocked, Boolean isBlocking, OffsetDateTime modifiedAtAfter, OffsetDateTime modifiedAtBefore, LocalDate dueOnBefore, LocalDate modifiedOn, LocalDate modifiedOnAfter, LocalDate modifiedOnBefore, OffsetDateTime completedAtAfter, OffsetDateTime completedAtBefore, LocalDate completedOn, LocalDate completedOnAfter, LocalDate completedOnBefore, OffsetDateTime createdAtAfter, String commentedOnByNot, OffsetDateTime createdAtBefore, LocalDate createdOn, LocalDate createdOnAfter, LocalDate createdOnBefore, LocalDate startOn, LocalDate startOnAfter, LocalDate startOnBefore, OffsetDateTime dueAtAfter, OffsetDateTime dueAtBefore, LocalDate dueOn, String commentedOnByAny, LocalDate dueOnAfter, String likedByNot, String likedByAny, String assignedByNot, String assignedByAny, String createdByNot, String createdByAny, String followersNot, String followersAny, String teamsAny, String tagsAll, String tagsNot, String tagsAny, String sectionsAll, String sectionsNot, String sectionsAny, String projectsAll, String projectsNot, String projectsAny, String assigneeStatus, String assigneeNot, String assigneeAny, String resourceSubtype, String text, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/workspaces/{workspace_gid}/tasks/search".replace("{workspace_gid}", workspaceGid);
+
+                CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("text", text)
+                    .query("resource_subtype", resourceSubtype)
+                    .query("assignee.any", assigneeAny)
+                    .query("assignee.not", assigneeNot)
+                    .query("assignee_status", assigneeStatus)
+                    .query("projects.any", projectsAny)
+                    .query("projects.not", projectsNot)
+                    .query("projects.all", projectsAll)
+                    .query("sections.any", sectionsAny)
+                    .query("sections.not", sectionsNot)
+                    .query("sections.all", sectionsAll)
+                    .query("tags.any", tagsAny)
+                    .query("tags.not", tagsNot)
+                    .query("tags.all", tagsAll)
+                    .query("teams.any", teamsAny)
+                    .query("followers.any", followersAny)
+                    .query("followers.not", followersNot)
+                    .query("created_by.any", createdByAny)
+                    .query("created_by.not", createdByNot)
+                    .query("assigned_by.any", assignedByAny)
+                    .query("assigned_by.not", assignedByNot)
+                    .query("liked_by.any", likedByAny)
+                    .query("liked_by.not", likedByNot)
+                    .query("commented_on_by.any", commentedOnByAny)
+                    .query("commented_on_by.not", commentedOnByNot)
+                    .query("due_on.before", dueOnBefore)
+                    .query("due_on.after", dueOnAfter)
+                    .query("due_on", dueOn)
+                    .query("due_at.before", dueAtBefore)
+                    .query("due_at.after", dueAtAfter)
+                    .query("start_on.before", startOnBefore)
+                    .query("start_on.after", startOnAfter)
+                    .query("start_on", startOn)
+                    .query("created_on.before", createdOnBefore)
+                    .query("created_on.after", createdOnAfter)
+                    .query("created_on", createdOn)
+                    .query("created_at.before", createdAtBefore)
+                    .query("created_at.after", createdAtAfter)
+                    .query("completed_on.before", completedOnBefore)
+                    .query("completed_on.after", completedOnAfter)
+                    .query("completed_on", completedOn)
+                    .query("completed_at.before", completedAtBefore)
+                    .query("completed_at.after", completedAtAfter)
+                    .query("modified_on.before", modifiedOnBefore)
+                    .query("modified_on.after", modifiedOnAfter)
+                    .query("modified_on", modifiedOn)
+                    .query("modified_at.before", modifiedAtBefore)
+                    .query("modified_at.after", modifiedAtAfter)
+                    .query("is_blocking", isBlocking)
+                    .query("is_blocked", isBlocked)
+                    .query("has_attachment", hasAttachment)
+                    .query("completed", completed)
+                    .query("is_subtask", isSubtask)
+                    .query("sort_by", sortBy)
+                    .query("sort_ascending", sortAscending);
+
+                return req;
+            }
+
+            public CollectionRequest<Task> searchTasksForWorkspace(String workspaceGid, Boolean sortAscending, String sortBy, Boolean isSubtask, Boolean completed, Boolean hasAttachment, Boolean isBlocked, Boolean isBlocking, OffsetDateTime modifiedAtAfter, OffsetDateTime modifiedAtBefore, LocalDate dueOnBefore, LocalDate modifiedOn, LocalDate modifiedOnAfter, LocalDate modifiedOnBefore, OffsetDateTime completedAtAfter, OffsetDateTime completedAtBefore, LocalDate completedOn, LocalDate completedOnAfter, LocalDate completedOnBefore, OffsetDateTime createdAtAfter, String commentedOnByNot, OffsetDateTime createdAtBefore, LocalDate createdOn, LocalDate createdOnAfter, LocalDate createdOnBefore, LocalDate startOn, LocalDate startOnAfter, LocalDate startOnBefore, OffsetDateTime dueAtAfter, OffsetDateTime dueAtBefore, LocalDate dueOn, String commentedOnByAny, LocalDate dueOnAfter, String likedByNot, String likedByAny, String assignedByNot, String assignedByAny, String createdByNot, String createdByAny, String followersNot, String followersAny, String teamsAny, String tagsAll, String tagsNot, String tagsAny, String sectionsAll, String sectionsNot, String sectionsAny, String projectsAll, String projectsNot, String projectsAny, String assigneeStatus, String assigneeNot, String assigneeAny, String resourceSubtype, String text) throws IOException {
+                return searchTasksForWorkspace(workspaceGid, sortAscending, sortBy, isSubtask, completed, hasAttachment, isBlocked, isBlocking, modifiedAtAfter, modifiedAtBefore, dueOnBefore, modifiedOn, modifiedOnAfter, modifiedOnBefore, completedAtAfter, completedAtBefore, completedOn, completedOnAfter, completedOnBefore, createdAtAfter, commentedOnByNot, createdAtBefore, createdOn, createdOnAfter, createdOnBefore, startOn, startOnAfter, startOnBefore, dueAtAfter, dueAtBefore, dueOn, commentedOnByAny, dueOnAfter, likedByNot, likedByAny, assignedByNot, assignedByAny, createdByNot, createdByAny, followersNot, followersAny, teamsAny, tagsAll, tagsNot, tagsAny, sectionsAll, sectionsNot, sectionsAny, projectsAll, projectsNot, projectsAny, assigneeStatus, assigneeNot, assigneeAny, resourceSubtype, text, null, false);
+            }
+
+            /**
+            * Set the parent of a task
+            * parent, or no parent task at all. Returns an empty data block. When using &#x60;insert_before&#x60; and &#x60;insert_after&#x60;, at most one of those two options can be specified, and they must already be subtasks of the parent.
+                * @param taskGid The task to operate on. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Task>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Task> setParentForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tasks/{task_gid}/setParent".replace("{task_gid}", taskGid);
+
+                ItemRequest<Task> req = new ItemRequest<Task>(this, Task.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<Task> setParentForTask(String taskGid) throws IOException {
+                return setParentForTask(taskGid, null, false);
+            }
+
+            /**
+            * Update a task
+            * A specific, existing task can be updated by making a PUT request on the URL for that task. Only the fields provided in the &#x60;data&#x60; block will be updated; any unspecified fields will remain unchanged.  When using this method, it is best to specify only those fields you wish to change, or else you may overwrite changes made by another user since you last retrieved the task.  Returns the complete updated task record.
+                * @param taskGid The task to operate on. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Task>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Task> updateTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/tasks/{task_gid}".replace("{task_gid}", taskGid);
+
+                ItemRequest<Task> req = new ItemRequest<Task>(this, Task.class, path, "PUT")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<Task> updateTask(String taskGid) throws IOException {
+                return updateTask(taskGid, null, false);
+            }
+
     }
-
-    /**
-     * Creating a new task is as easy as POSTing to the `/tasks` endpoint
-     * with a data block containing the fields you'd like to set on the task.
-     * Any unspecified fields will take on default values.
-     *
-     * Every task is required to be created in a specific workspace, and this
-     * workspace cannot be changed once set. The workspace need not be set
-     * explicitly if you specify `projects` or a `parent` task instead.
-     *
-     * `projects` can be a comma separated list of projects, or just a single
-     * project the task should belong to.
-     *
-     * @return Request object
-     */
-    public ItemRequest<Task> create() {
-
-        return new ItemRequest<Task>(this, Task.class, "/tasks", "POST");
-    }
-
-    /**
-     * Creating a new task is as easy as POSTing to the `/tasks` endpoint
-     * with a data block containing the fields you'd like to set on the task.
-     * Any unspecified fields will take on default values.
-     *
-     * Every task is required to be created in a specific workspace, and this
-     * workspace cannot be changed once set. The workspace need not be set
-     * explicitly if you specify a `project` or a `parent` task instead.
-     *
-     * @param  workspace The workspace to create a task in.
-     * @return Request object
-     */
-    public ItemRequest<Task> createInWorkspace(String workspace) {
-
-        String path = String.format("/workspaces/%s/tasks", workspace);
-        return new ItemRequest<Task>(this, Task.class, path, "POST");
-    }
-
-    /**
-     * Returns the complete task record for a single task.
-     *
-     * @param  task The task to get.
-     * @return Request object
-     */
-    public ItemRequest<Task> findById(String task) {
-
-        String path = String.format("/tasks/%s", task);
-        return new ItemRequest<Task>(this, Task.class, path, "GET");
-    }
-
-    /**
-     * A specific, existing task can be updated by making a PUT request on the
-     * URL for that task. Only the fields provided in the `data` block will be
-     * updated; any unspecified fields will remain unchanged.
-     *
-     * When using this method, it is best to specify only those fields you wish
-     * to change, or else you may overwrite changes made by another user since
-     * you last retrieved the task.
-     *
-     * Returns the complete updated task record.
-     *
-     * @param  task The task to update.
-     * @return Request object
-     */
-    public ItemRequest<Task> update(String task) {
-
-        String path = String.format("/tasks/%s", task);
-        return new ItemRequest<Task>(this, Task.class, path, "PUT");
-    }
-
-    /**
-     * A specific, existing task can be deleted by making a DELETE request on the
-     * URL for that task. Deleted tasks go into the "trash" of the user making
-     * the delete request. Tasks can be recovered from the trash within a period
-     * of 30 days; afterward they are completely removed from the system.
-     *
-     * Returns an empty data record.
-     *
-     * @param  task The task to delete.
-     * @return Request object
-     */
-    public ItemRequest<Task> delete(String task) {
-
-        String path = String.format("/tasks/%s", task);
-        return new ItemRequest<Task>(this, Task.class, path, "DELETE");
-    }
-
-    /**
-     * Creates and returns a job that will asynchronously handle the duplication.
-     *
-     * @param  task The task to duplicate.
-     * @return Request object
-     */
-    public ItemRequest<Job> duplicateTask(String task) {
-
-        String path = String.format("/tasks/%s/duplicate", task);
-        return new ItemRequest<Job>(this, Job.class, path, "POST");
-    }
-
-    /**
-     * Returns the compact task records for all tasks within the given project,
-     * ordered by their priority within the project.
-     *
-     * @param  project The project in which to search for tasks.
-     * @return Request object
-     */
-    public CollectionRequest<Task> findByProject(String project) {
-
-        String path = String.format("/projects/%s/tasks", project);
-        return new CollectionRequest<Task>(this, Task.class, path, "GET");
-    }
-
-    /**
-     * Returns the compact task records for all tasks with the given tag.
-     *
-     * @param  tag The tag in which to search for tasks.
-     * @return Request object
-     */
-    public CollectionRequest<Task> findByTag(String tag) {
-
-        String path = String.format("/tags/%s/tasks", tag);
-        return new CollectionRequest<Task>(this, Task.class, path, "GET");
-    }
-
-    /**
-     * <b>Board view only:</b> Returns the compact section records for all tasks within the given section.
-     *
-     * @param  section The section in which to search for tasks.
-     * @return Request object
-     */
-    public CollectionRequest<Task> findBySection(String section) {
-
-        String path = String.format("/sections/%s/tasks", section);
-        return new CollectionRequest<Task>(this, Task.class, path, "GET");
-    }
-
-    /**
-     * Returns the compact list of tasks in a user's My Tasks list. The returned
-     * tasks will be in order within each assignee status group of `Inbox`,
-     * `Today`, and `Upcoming`.
-     *
-     * **Note:** tasks in `Later` have a different ordering in the Asana web app
-     * than the other assignee status groups; this endpoint will still return
-     * them in list order in `Later` (differently than they show up in Asana,
-     * but the same order as in Asana's mobile apps).
-     *
-     * **Note:** Access control is enforced for this endpoint as with all Asana
-     * API endpoints, meaning a user's private tasks will be filtered out if the
-     * API-authenticated user does not have access to them.
-     *
-     * **Note:** Both complete and incomplete tasks are returned by default
-     * unless they are filtered out (for example, setting `completed_since=now`
-     * will return only incomplete tasks, which is the default view for "My
-     * Tasks" in Asana.)
-     *
-     * @param  userTaskList The user task list in which to search for tasks.
-     * @return Request object
-     */
-    public CollectionRequest<Task> findByUserTaskList(String userTaskList) {
-
-        String path = String.format("/user_task_lists/%s/tasks", userTaskList);
-        return new CollectionRequest<Task>(this, Task.class, path, "GET");
-    }
-
-    /**
-     * Returns the compact task records for some filtered set of tasks. Use one
-     * or more of the parameters provided to filter the tasks returned. You must
-     * specify a `project`, `section`, `tag`, or `user_task_list` if you do not
-     * specify `assignee` and `workspace`.
-     *
-     * @return Request object
-     */
-    public CollectionRequest<Task> findAll() {
-
-        return new CollectionRequest<Task>(this, Task.class, "/tasks", "GET");
-    }
-
-    /**
-     * Returns the compact task records for all tasks with the given tag.
-     * Tasks can have more than one tag at a time.
-     *
-     * @param  tag The tag to fetch tasks from.
-     * @return Request object
-     */
-    public CollectionRequest<Task> getTasksWithTag(String tag) {
-
-        String path = String.format("/tags/%s/tasks", tag);
-        return new CollectionRequest<Task>(this, Task.class, path, "GET");
-    }
-
-    /**
-     * The search endpoint allows you to build complex queries to find and fetch exactly the data you need from Asana. For a more comprehensive description of all the query parameters and limitations of this endpoint, see our [long-form documentation](/developers/documentation/getting-started/search-api) for this feature.
-     *
-     * @param  workspace The workspace or organization in which to search for tasks.
-     * @return Request object
-     */
-    public CollectionRequest<Task> searchInWorkspace(String workspace) {
-
-        String path = String.format("/workspaces/%s/tasks/search", workspace);
-        return new CollectionRequest<Task>(this, Task.class, path, "GET");
-    }
-
-    /**
-     * Returns the compact representations of all of the dependencies of a task.
-     *
-     * @param  task The task to get dependencies on.
-     * @return Request object
-     */
-    public ItemRequest<Task> dependencies(String task) {
-
-        String path = String.format("/tasks/%s/dependencies", task);
-        return new ItemRequest<Task>(this, Task.class, path, "GET");
-    }
-
-    /**
-     * Returns the compact representations of all of the dependents of a task.
-     *
-     * @param  task The task to get dependents on.
-     * @return Request object
-     */
-    public ItemRequest<Task> dependents(String task) {
-
-        String path = String.format("/tasks/%s/dependents", task);
-        return new ItemRequest<Task>(this, Task.class, path, "GET");
-    }
-
-    /**
-     * Marks a set of tasks as dependencies of this task, if they are not
-     * already dependencies. *A task can have at most 15 dependencies.*
-     *
-     * @param  task The task to add dependencies to.
-     * @return Request object
-     */
-    public ItemRequest<Task> addDependencies(String task) {
-
-        String path = String.format("/tasks/%s/addDependencies", task);
-        return new ItemRequest<Task>(this, Task.class, path, "POST");
-    }
-
-    /**
-     * Marks a set of tasks as dependents of this task, if they are not already
-     * dependents. *A task can have at most 30 dependents.*
-     *
-     * @param  task The task to add dependents to.
-     * @return Request object
-     */
-    public ItemRequest<Task> addDependents(String task) {
-
-        String path = String.format("/tasks/%s/addDependents", task);
-        return new ItemRequest<Task>(this, Task.class, path, "POST");
-    }
-
-    /**
-     * Unlinks a set of dependencies from this task.
-     *
-     * @param  task The task to remove dependencies from.
-     * @return Request object
-     */
-    public ItemRequest<Task> removeDependencies(String task) {
-
-        String path = String.format("/tasks/%s/removeDependencies", task);
-        return new ItemRequest<Task>(this, Task.class, path, "POST");
-    }
-
-    /**
-     * Unlinks a set of dependents from this task.
-     *
-     * @param  task The task to remove dependents from.
-     * @return Request object
-     */
-    public ItemRequest<Task> removeDependents(String task) {
-
-        String path = String.format("/tasks/%s/removeDependents", task);
-        return new ItemRequest<Task>(this, Task.class, path, "POST");
-    }
-
-    /**
-     * Adds each of the specified followers to the task, if they are not already
-     * following. Returns the complete, updated record for the affected task.
-     *
-     * @param  task The task to add followers to.
-     * @return Request object
-     */
-    public ItemRequest<Task> addFollowers(String task) {
-
-        String path = String.format("/tasks/%s/addFollowers", task);
-        return new ItemRequest<Task>(this, Task.class, path, "POST");
-    }
-
-    /**
-     * Removes each of the specified followers from the task if they are
-     * following. Returns the complete, updated record for the affected task.
-     *
-     * @param  task The task to remove followers from.
-     * @return Request object
-     */
-    public ItemRequest<Task> removeFollowers(String task) {
-
-        String path = String.format("/tasks/%s/removeFollowers", task);
-        return new ItemRequest<Task>(this, Task.class, path, "POST");
-    }
-
-    /**
-     * Returns a compact representation of all of the projects the task is in.
-     *
-     * @param  task The task to get projects on.
-     * @return Request object
-     */
-    public CollectionRequest<Task> projects(String task) {
-
-        String path = String.format("/tasks/%s/projects", task);
-        return new CollectionRequest<Task>(this, Task.class, path, "GET");
-    }
-
-    /**
-     * Adds the task to the specified project, in the optional location
-     * specified. If no location arguments are given, the task will be added to
-     * the end of the project.
-     *
-     * `addProject` can also be used to reorder a task within a project or section that
-     * already contains it.
-     *
-     * At most one of `insert_before`, `insert_after`, or `section` should be
-     * specified. Inserting into a section in an non-order-dependent way can be
-     * done by specifying `section`, otherwise, to insert within a section in a
-     * particular place, specify `insert_before` or `insert_after` and a task
-     * within the section to anchor the position of this task.
-     *
-     * Returns an empty data block.
-     *
-     * @param  task The task to add to a project.
-     * @return Request object
-     */
-    public ItemRequest<Task> addProject(String task) {
-
-        String path = String.format("/tasks/%s/addProject", task);
-        return new ItemRequest<Task>(this, Task.class, path, "POST");
-    }
-
-    /**
-     * Removes the task from the specified project. The task will still exist
-     * in the system, but it will not be in the project anymore.
-     *
-     * Returns an empty data block.
-     *
-     * @param  task The task to remove from a project.
-     * @return Request object
-     */
-    public ItemRequest<Task> removeProject(String task) {
-
-        String path = String.format("/tasks/%s/removeProject", task);
-        return new ItemRequest<Task>(this, Task.class, path, "POST");
-    }
-
-    /**
-     * Returns a compact representation of all of the tags the task has.
-     *
-     * @param  task The task to get tags on.
-     * @return Request object
-     */
-    public CollectionRequest<Task> tags(String task) {
-
-        String path = String.format("/tasks/%s/tags", task);
-        return new CollectionRequest<Task>(this, Task.class, path, "GET");
-    }
-
-    /**
-     * Adds a tag to a task. Returns an empty data block.
-     *
-     * @param  task The task to add a tag to.
-     * @return Request object
-     */
-    public ItemRequest<Task> addTag(String task) {
-
-        String path = String.format("/tasks/%s/addTag", task);
-        return new ItemRequest<Task>(this, Task.class, path, "POST");
-    }
-
-    /**
-     * Removes a tag from the task. Returns an empty data block.
-     *
-     * @param  task The task to remove a tag from.
-     * @return Request object
-     */
-    public ItemRequest<Task> removeTag(String task) {
-
-        String path = String.format("/tasks/%s/removeTag", task);
-        return new ItemRequest<Task>(this, Task.class, path, "POST");
-    }
-
-    /**
-     * Returns a compact representation of all of the subtasks of a task.
-     *
-     * @param  task The task to get the subtasks of.
-     * @return Request object
-     */
-    public CollectionRequest<Task> subtasks(String task) {
-
-        String path = String.format("/tasks/%s/subtasks", task);
-        return new CollectionRequest<Task>(this, Task.class, path, "GET");
-    }
-
-    /**
-     * Creates a new subtask and adds it to the parent task. Returns the full record
-     * for the newly created subtask.
-     *
-     * @param  task The task to add a subtask to.
-     * @return Request object
-     */
-    public ItemRequest<Task> addSubtask(String task) {
-
-        String path = String.format("/tasks/%s/subtasks", task);
-        return new ItemRequest<Task>(this, Task.class, path, "POST");
-    }
-
-    /**
-     * Returns a compact representation of all of the stories on the task.
-     *
-     * @param  task The task containing the stories to get.
-     * @return Request object
-     */
-    public CollectionRequest<Task> stories(String task) {
-
-        String path = String.format("/tasks/%s/stories", task);
-        return new CollectionRequest<Task>(this, Task.class, path, "GET");
-    }
-
-    /**
-     * Adds a comment to a task. The comment will be authored by the
-     * currently authenticated user, and timestamped when the server receives
-     * the request.
-     *
-     * Returns the full record for the new story added to the task.
-     *
-     * @param  task Globally unique identifier for the task.
-     * @return Request object
-     */
-    public ItemRequest<Task> addComment(String task) {
-
-        String path = String.format("/tasks/%s/stories", task);
-        return new ItemRequest<Task>(this, Task.class, path, "POST");
-    }
-
-    /**
-     * Insert or reorder tasks in a user's My Tasks list. If the task was not
-     * assigned to the owner of the user task list it will be reassigned when
-     * this endpoint is called. If neither `insert_before` nor `insert_after`
-     * are provided the task will be inserted at the top of the assignee's
-     * inbox.
-     *
-     * Returns an empty data block.
-     *
-     * @param  userTaskList Globally unique identifier for the user task list.
-     * @return Request object
-     */
-    public ItemRequest<Task> insertInUserTaskList(String userTaskList) {
-
-        String path = String.format("/user_task_lists/%s/tasks/insert", userTaskList);
-        return new ItemRequest<Task>(this, Task.class, path, "POST");
-    }
-}

--- a/src/main/java/com/asana/resources/gen/TasksBase.java
+++ b/src/main/java/com/asana/resources/gen/TasksBase.java
@@ -464,20 +464,20 @@ import java.util.List;
             * @param taskGid The task to operate on. (required)
             * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
             * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-        * @return CollectionRequest<Task>
+        * @return CollectionRequest<JsonElement>
         * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
         */
-        public CollectionRequest<Task> removeDependenciesForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+        public CollectionRequest<JsonElement> removeDependenciesForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
             String path = "/tasks/{task_gid}/removeDependencies".replace("{task_gid}", taskGid);
 
-            CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "POST")
+            CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "POST")
                 .query("opt_pretty", optPretty)
                 .query("opt_fields", optFields);
 
             return req;
         }
 
-        public CollectionRequest<Task> removeDependenciesForTask(String taskGid) throws IOException {
+        public CollectionRequest<JsonElement> removeDependenciesForTask(String taskGid) throws IOException {
             return removeDependenciesForTask(taskGid, null, false);
         }
         /**
@@ -486,20 +486,20 @@ import java.util.List;
             * @param taskGid The task to operate on. (required)
             * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
             * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-        * @return CollectionRequest<Task>
+        * @return CollectionRequest<JsonElement>
         * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
         */
-        public CollectionRequest<Task> removeDependentsForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
+        public CollectionRequest<JsonElement> removeDependentsForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
             String path = "/tasks/{task_gid}/removeDependents".replace("{task_gid}", taskGid);
 
-            CollectionRequest<Task> req = new CollectionRequest<Task>(this, Task.class, path, "POST")
+            CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "POST")
                 .query("opt_pretty", optPretty)
                 .query("opt_fields", optFields);
 
             return req;
         }
 
-        public CollectionRequest<Task> removeDependentsForTask(String taskGid) throws IOException {
+        public CollectionRequest<JsonElement> removeDependentsForTask(String taskGid) throws IOException {
             return removeDependentsForTask(taskGid, null, false);
         }
         /**

--- a/src/main/java/com/asana/resources/gen/TeamMembershipsBase.java
+++ b/src/main/java/com/asana/resources/gen/TeamMembershipsBase.java
@@ -44,7 +44,7 @@ import java.util.List;
         * Get team memberships
         * Returns compact team membership records.
             * @param workspace Globally unique identifier for the workspace. This parameter must be used with the user parameter. (optional)
-            * @param user Globally unique identifier for the user. This parameter must be used with the workspace parameter. (optional)
+            * @param user A string identifying a user. This can either be the string \&quot;me\&quot;, an email, or the gid of a user. This parameter must be used with the workspace parameter. (optional)
             * @param team Globally unique identifier for the team. (optional)
             * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
             * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
@@ -100,7 +100,7 @@ import java.util.List;
         /**
         * Get memberships from a user
         * Returns the compact team membership records for the user.
-            * @param userGid Globally unique identifier for the user. (required)
+            * @param userGid A string identifying a user. This can either be the string \&quot;me\&quot;, an email, or the gid of a user. (required)
             * @param workspace Globally unique identifier for the workspace. (required)
             * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
             * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)

--- a/src/main/java/com/asana/resources/gen/TeamMembershipsBase.java
+++ b/src/main/java/com/asana/resources/gen/TeamMembershipsBase.java
@@ -9,73 +9,82 @@ import com.google.gson.JsonElement;
 import java.io.IOException;
 import java.util.List;
 
-    public class StoriesBase extends Resource {
+    public class TeamMembershipsBase extends Resource {
     /**
     * @param client Parent client instance
     */
-    public StoriesBase(Client client) { super(client); }
+    public TeamMembershipsBase(Client client) { super(client); }
 
             /**
-            * Create a story on a task
-            * Adds a story to a task. This endpoint currently only allows for comment stories to be created. The comment will be authored by the currently authenticated user, and timestamped when the server receives the request.  Returns the full record for the new story added to the task.
-                * @param taskGid The task to operate on. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Story>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Story> createStoryForTask(String taskGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}/stories".replace("{task_gid}", taskGid);
-
-                ItemRequest<Story> req = new ItemRequest<Story>(this, Story.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<Story> createStoryForTask(String taskGid) throws IOException {
-                return createStoryForTask(taskGid, null, false);
-            }
-
-            /**
-            * Delete a story
-            * Deletes a story. A user can only delete stories they have created.  Returns an empty data record.
-                * @param storyGid Globally unique identifier for the story. (required)
+            * Get a team membership
+            * Returns the complete team membership record for a single team membership.
+                * @param teamMembershipGid  (required)
                 * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
                 * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
             * @return ItemRequest<JsonElement>
             * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
             */
-            public ItemRequest<JsonElement> deleteStory(String storyGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/stories/{story_gid}".replace("{story_gid}", storyGid);
+            public ItemRequest<JsonElement> getTeamMembership(String teamMembershipGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/team_memberships/{team_membership_gid}".replace("{team_membership_gid}", teamMembershipGid);
 
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "GET")
                     .query("opt_pretty", optPretty)
                     .query("opt_fields", optFields);
 
                 return req;
             }
 
-            public ItemRequest<JsonElement> deleteStory(String storyGid) throws IOException {
-                return deleteStory(storyGid, null, false);
+            public ItemRequest<JsonElement> getTeamMembership(String teamMembershipGid) throws IOException {
+                return getTeamMembership(teamMembershipGid, null, false);
             }
 
             /**
-            * Get stories from a task
-            * Returns the compact records for all stories on the task.
-                * @param taskGid The task to operate on. (required)
+            * Get team memberships
+            * Returns compact team membership records.
+                * @param workspace Globally unique identifier for the workspace. This parameter must be used with the user parameter. (optional)
+                * @param user Globally unique identifier for the user. This parameter must be used with the workspace parameter. (optional)
+                * @param team Globally unique identifier for the team. (optional)
                 * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
                 * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
                 * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
                 * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Story>
+            * @return CollectionRequest<JsonElement>
             * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
             */
-            public CollectionRequest<Story> getStoriesForTask(String taskGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/tasks/{task_gid}/stories".replace("{task_gid}", taskGid);
+            public CollectionRequest<JsonElement> getTeamMemberships(String workspace, String user, String team, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/team_memberships";
 
-                CollectionRequest<Story> req = new CollectionRequest<Story>(this, Story.class, path, "GET")
+                CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset)
+                    .query("team", team)
+                    .query("user", user)
+                    .query("workspace", workspace);
+
+                return req;
+            }
+
+            public CollectionRequest<JsonElement> getTeamMemberships(String workspace, String user, String team) throws IOException {
+                return getTeamMemberships(workspace, user, team, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Get memberships from a team
+            * Returns the compact team memberships for the team.
+                * @param teamGid Globally unique identifier for the team. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<JsonElement> getTeamMembershipsForTeam(String teamGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/teams/{team_gid}/team_memberships".replace("{team_gid}", teamGid);
+
+                CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "GET")
                     .query("opt_pretty", optPretty)
                     .query("opt_fields", optFields)
                     .query("limit", limit)
@@ -84,58 +93,37 @@ import java.util.List;
                 return req;
             }
 
-            public CollectionRequest<Story> getStoriesForTask(String taskGid) throws IOException {
-                return getStoriesForTask(taskGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            public CollectionRequest<JsonElement> getTeamMembershipsForTeam(String teamGid) throws IOException {
+                return getTeamMembershipsForTeam(teamGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
             }
 
             /**
-            * Get a story
-            * Returns the full record for a single story.
-                * @param storyGid Globally unique identifier for the story. (required)
+            * Get memberships from a user
+            * Returns the compact team membership records for the user.
+                * @param userGid Globally unique identifier for the user. (required)
+                * @param workspace Globally unique identifier for the workspace. (required)
                 * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
                 * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
                 * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
                 * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Story>
+            * @return CollectionRequest<JsonElement>
             * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
             */
-            public ItemRequest<Story> getStory(String storyGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/stories/{story_gid}".replace("{story_gid}", storyGid);
+            public CollectionRequest<JsonElement> getTeamMembershipsForUser(String userGid, String workspace, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/users/{user_gid}/team_memberships".replace("{user_gid}", userGid);
 
-                ItemRequest<Story> req = new ItemRequest<Story>(this, Story.class, path, "GET")
+                CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "GET")
                     .query("opt_pretty", optPretty)
                     .query("opt_fields", optFields)
                     .query("limit", limit)
-                    .query("offset", offset);
+                    .query("offset", offset)
+                    .query("workspace", workspace);
 
                 return req;
             }
 
-            public ItemRequest<Story> getStory(String storyGid) throws IOException {
-                return getStory(storyGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
-            /**
-            * Update a story
-            * Updates the story and returns the full record for the updated story. Only comment stories can have their text updated, and only comment stories and attachment stories can be pinned. Only one of &#x60;text&#x60; and &#x60;html_text&#x60; can be specified.
-                * @param storyGid Globally unique identifier for the story. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Story>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Story> updateStory(String storyGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/stories/{story_gid}".replace("{story_gid}", storyGid);
-
-                ItemRequest<Story> req = new ItemRequest<Story>(this, Story.class, path, "PUT")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<Story> updateStory(String storyGid) throws IOException {
-                return updateStory(storyGid, null, false);
+            public CollectionRequest<JsonElement> getTeamMembershipsForUser(String userGid, String workspace) throws IOException {
+                return getTeamMembershipsForUser(userGid, workspace, null, (int)Client.DEFAULTS.get("page_size"), null, false);
             }
 
     }

--- a/src/main/java/com/asana/resources/gen/TeamMembershipsBase.java
+++ b/src/main/java/com/asana/resources/gen/TeamMembershipsBase.java
@@ -4,9 +4,12 @@ import com.asana.Client;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
+import com.asana.models.*;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
     public class TeamMembershipsBase extends Resource {
@@ -15,115 +18,111 @@ import java.util.List;
     */
     public TeamMembershipsBase(Client client) { super(client); }
 
-            /**
-            * Get a team membership
-            * Returns the complete team membership record for a single team membership.
-                * @param teamMembershipGid  (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> getTeamMembership(String teamMembershipGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/team_memberships/{team_membership_gid}".replace("{team_membership_gid}", teamMembershipGid);
+        /**
+        * Get a team membership
+        * Returns the complete team membership record for a single team membership.
+            * @param teamMembershipGid  (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> getTeamMembership(String teamMembershipGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/team_memberships/{team_membership_gid}".replace("{team_membership_gid}", teamMembershipGid);
 
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                return req;
-            }
+            return req;
+        }
 
-            public ItemRequest<JsonElement> getTeamMembership(String teamMembershipGid) throws IOException {
-                return getTeamMembership(teamMembershipGid, null, false);
-            }
+        public ItemRequest<JsonElement> getTeamMembership(String teamMembershipGid) throws IOException {
+            return getTeamMembership(teamMembershipGid, null, false);
+        }
+        /**
+        * Get team memberships
+        * Returns compact team membership records.
+            * @param workspace Globally unique identifier for the workspace. This parameter must be used with the user parameter. (optional)
+            * @param user Globally unique identifier for the user. This parameter must be used with the workspace parameter. (optional)
+            * @param team Globally unique identifier for the team. (optional)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<JsonElement> getTeamMemberships(String workspace, String user, String team, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/team_memberships";
 
-            /**
-            * Get team memberships
-            * Returns compact team membership records.
-                * @param workspace Globally unique identifier for the workspace. This parameter must be used with the user parameter. (optional)
-                * @param user Globally unique identifier for the user. This parameter must be used with the workspace parameter. (optional)
-                * @param team Globally unique identifier for the team. (optional)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<JsonElement> getTeamMemberships(String workspace, String user, String team, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/team_memberships";
+            CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset)
+                .query("team", team)
+                .query("user", user)
+                .query("workspace", workspace);
 
-                CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset)
-                    .query("team", team)
-                    .query("user", user)
-                    .query("workspace", workspace);
+            return req;
+        }
 
-                return req;
-            }
+        public CollectionRequest<JsonElement> getTeamMemberships(String workspace, String user, String team) throws IOException {
+            return getTeamMemberships(workspace, user, team, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Get memberships from a team
+        * Returns the compact team memberships for the team.
+            * @param teamGid Globally unique identifier for the team. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<JsonElement> getTeamMembershipsForTeam(String teamGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/teams/{team_gid}/team_memberships".replace("{team_gid}", teamGid);
 
-            public CollectionRequest<JsonElement> getTeamMemberships(String workspace, String user, String team) throws IOException {
-                return getTeamMemberships(workspace, user, team, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
+            CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-            /**
-            * Get memberships from a team
-            * Returns the compact team memberships for the team.
-                * @param teamGid Globally unique identifier for the team. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<JsonElement> getTeamMembershipsForTeam(String teamGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/teams/{team_gid}/team_memberships".replace("{team_gid}", teamGid);
+            return req;
+        }
 
-                CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
+        public CollectionRequest<JsonElement> getTeamMembershipsForTeam(String teamGid) throws IOException {
+            return getTeamMembershipsForTeam(teamGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Get memberships from a user
+        * Returns the compact team membership records for the user.
+            * @param userGid Globally unique identifier for the user. (required)
+            * @param workspace Globally unique identifier for the workspace. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<JsonElement> getTeamMembershipsForUser(String userGid, String workspace, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/users/{user_gid}/team_memberships".replace("{user_gid}", userGid);
 
-                return req;
-            }
+            CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset)
+                .query("workspace", workspace);
 
-            public CollectionRequest<JsonElement> getTeamMembershipsForTeam(String teamGid) throws IOException {
-                return getTeamMembershipsForTeam(teamGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
+            return req;
+        }
 
-            /**
-            * Get memberships from a user
-            * Returns the compact team membership records for the user.
-                * @param userGid Globally unique identifier for the user. (required)
-                * @param workspace Globally unique identifier for the workspace. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<JsonElement> getTeamMembershipsForUser(String userGid, String workspace, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/users/{user_gid}/team_memberships".replace("{user_gid}", userGid);
-
-                CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset)
-                    .query("workspace", workspace);
-
-                return req;
-            }
-
-            public CollectionRequest<JsonElement> getTeamMembershipsForUser(String userGid, String workspace) throws IOException {
-                return getTeamMembershipsForUser(userGid, workspace, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
+        public CollectionRequest<JsonElement> getTeamMembershipsForUser(String userGid, String workspace) throws IOException {
+            return getTeamMembershipsForUser(userGid, workspace, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
     }

--- a/src/main/java/com/asana/resources/gen/TeamsBase.java
+++ b/src/main/java/com/asana/resources/gen/TeamsBase.java
@@ -2,98 +2,147 @@ package com.asana.resources.gen;
 
 import com.asana.Client;
 import com.asana.resources.Resource;
-import com.asana.models.Team;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
+import com.asana.models.Team;
+import com.google.gson.JsonElement;
 
-/**
- * A _team_ is used to group related projects and people together within an
- * organization. Each project in an organization is associated with a team.
- */
-public class TeamsBase extends Resource {
-    /**
-     * @param client Parent client instance
-     */
-    public TeamsBase(Client client) {
-        super(client);
-    }
+import java.io.IOException;
+import java.util.List;
 
+    public class TeamsBase extends Resource {
     /**
-     * Returns the full record for a single team.
-     *
-     * @param  team Globally unique identifier for the team.
-     * @return Request object
-     */
-    public ItemRequest<Team> findById(String team) {
-    
-        String path = String.format("/teams/%s", team);
-        return new ItemRequest<Team>(this, Team.class, path, "GET");
-    }
+    * @param client Parent client instance
+    */
+    public TeamsBase(Client client) { super(client); }
 
-    /**
-     * Returns the compact records for all teams in the organization visible to
-     * the authorized user.
-     *
-     * @param  organization Globally unique identifier for the workspace or organization.
-     * @return Request object
-     */
-    public CollectionRequest<Team> findByOrganization(String organization) {
-    
-        String path = String.format("/organizations/%s/teams", organization);
-        return new CollectionRequest<Team>(this, Team.class, path, "GET");
-    }
+            /**
+            * Add a user to a team
+            * The user making this call must be a member of the team in order to add others. The user being added must exist in the same organization as the team.
+                * @param teamGid Globally unique identifier for the team. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<User>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<User> addUserForTeam(String teamGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/teams/{team_gid}/addUser".replace("{team_gid}", teamGid);
 
-    /**
-     * Returns the compact records for all teams to which user is assigned.
-     *
-     * @param  user An identifier for the user. Can be one of an email address,
-     * the globally unique identifier for the user, or the keyword `me`
-     * to indicate the current user making the request.
-     * @return Request object
-     */
-    public CollectionRequest<Team> findByUser(String user) {
-    
-        String path = String.format("/users/%s/teams", user);
-        return new CollectionRequest<Team>(this, Team.class, path, "GET");
-    }
+                ItemRequest<User> req = new ItemRequest<User>(this, User.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
 
-    /**
-     * Returns the compact records for all users that are members of the team.
-     *
-     * @param  team Globally unique identifier for the team.
-     * @return Request object
-     */
-    public CollectionRequest<Team> users(String team) {
-    
-        String path = String.format("/teams/%s/users", team);
-        return new CollectionRequest<Team>(this, Team.class, path, "GET");
-    }
+                return req;
+            }
 
-    /**
-     * The user making this call must be a member of the team in order to add others.
-     * The user to add must exist in the same organization as the team in order to be added.
-     * The user to add can be referenced by their globally unique user ID or their email address.
-     * Returns the full user record for the added user.
-     *
-     * @param  team Globally unique identifier for the team.
-     * @return Request object
-     */
-    public ItemRequest<Team> addUser(String team) {
-    
-        String path = String.format("/teams/%s/addUser", team);
-        return new ItemRequest<Team>(this, Team.class, path, "POST");
-    }
+            public ItemRequest<User> addUserForTeam(String teamGid) throws IOException {
+                return addUserForTeam(teamGid, null, false);
+            }
 
-    /**
-     * The user to remove can be referenced by their globally unique user ID or their email address.
-     * Removes the user from the specified team. Returns an empty data record.
-     *
-     * @param  team Globally unique identifier for the team.
-     * @return Request object
-     */
-    public ItemRequest<Team> removeUser(String team) {
-    
-        String path = String.format("/teams/%s/removeUser", team);
-        return new ItemRequest<Team>(this, Team.class, path, "POST");
+            /**
+            * Get a team
+            * Returns the full record for a single team.
+                * @param teamGid Globally unique identifier for the team. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Team>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Team> getTeam(String teamGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/teams/{team_gid}".replace("{team_gid}", teamGid);
+
+                ItemRequest<Team> req = new ItemRequest<Team>(this, Team.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public ItemRequest<Team> getTeam(String teamGid) throws IOException {
+                return getTeam(teamGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Get teams in an organization
+            * Returns the compact records for all teams in the organization visible to the authorized user.
+                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Team>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Team> getTeamsForOrganization(String workspaceGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/organizations/{workspace_gid}/teams".replace("{workspace_gid}", workspaceGid);
+
+                CollectionRequest<Team> req = new CollectionRequest<Team>(this, Team.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public CollectionRequest<Team> getTeamsForOrganization(String workspaceGid) throws IOException {
+                return getTeamsForOrganization(workspaceGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Get teams for a user
+            * Returns the compact records for all teams to which the given user is assigned.
+                * @param userGid Globally unique identifier for the user. (required)
+                * @param organization The workspace or organization to filter teams on. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Team>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Team> getTeamsForUser(String userGid, String organization, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/users/{user_gid}/teams".replace("{user_gid}", userGid);
+
+                CollectionRequest<Team> req = new CollectionRequest<Team>(this, Team.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset)
+                    .query("organization", organization);
+
+                return req;
+            }
+
+            public CollectionRequest<Team> getTeamsForUser(String userGid, String organization) throws IOException {
+                return getTeamsForUser(userGid, organization, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Remove a user from a team
+            * The user making this call must be a member of the team in order to remove themselves or others.
+                * @param teamGid Globally unique identifier for the team. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> removeUserForTeam(String teamGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/teams/{team_gid}/removeUser".replace("{team_gid}", teamGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> removeUserForTeam(String teamGid) throws IOException {
+                return removeUserForTeam(teamGid, null, false);
+            }
+
     }
-}

--- a/src/main/java/com/asana/resources/gen/TeamsBase.java
+++ b/src/main/java/com/asana/resources/gen/TeamsBase.java
@@ -4,10 +4,12 @@ import com.asana.Client;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
-import com.asana.models.Team;
+import com.asana.models.*;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
     public class TeamsBase extends Resource {
@@ -16,133 +18,128 @@ import java.util.List;
     */
     public TeamsBase(Client client) { super(client); }
 
-            /**
-            * Add a user to a team
-            * The user making this call must be a member of the team in order to add others. The user being added must exist in the same organization as the team.
-                * @param teamGid Globally unique identifier for the team. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<User>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<User> addUserForTeam(String teamGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/teams/{team_gid}/addUser".replace("{team_gid}", teamGid);
+        /**
+        * Add a user to a team
+        * The user making this call must be a member of the team in order to add others. The user being added must exist in the same organization as the team.
+            * @param teamGid Globally unique identifier for the team. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<User>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<User> addUserForTeam(String teamGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/teams/{team_gid}/addUser".replace("{team_gid}", teamGid);
 
-                ItemRequest<User> req = new ItemRequest<User>(this, User.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            ItemRequest<User> req = new ItemRequest<User>(this, User.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                return req;
-            }
+            return req;
+        }
 
-            public ItemRequest<User> addUserForTeam(String teamGid) throws IOException {
-                return addUserForTeam(teamGid, null, false);
-            }
+        public ItemRequest<User> addUserForTeam(String teamGid) throws IOException {
+            return addUserForTeam(teamGid, null, false);
+        }
+        /**
+        * Get a team
+        * Returns the full record for a single team.
+            * @param teamGid Globally unique identifier for the team. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Team>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Team> getTeam(String teamGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/teams/{team_gid}".replace("{team_gid}", teamGid);
 
-            /**
-            * Get a team
-            * Returns the full record for a single team.
-                * @param teamGid Globally unique identifier for the team. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Team>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Team> getTeam(String teamGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/teams/{team_gid}".replace("{team_gid}", teamGid);
+            ItemRequest<Team> req = new ItemRequest<Team>(this, Team.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-                ItemRequest<Team> req = new ItemRequest<Team>(this, Team.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
+            return req;
+        }
 
-                return req;
-            }
+        public ItemRequest<Team> getTeam(String teamGid) throws IOException {
+            return getTeam(teamGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Get teams in an organization
+        * Returns the compact records for all teams in the organization visible to the authorized user.
+            * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Team>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Team> getTeamsForOrganization(String workspaceGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/organizations/{workspace_gid}/teams".replace("{workspace_gid}", workspaceGid);
 
-            public ItemRequest<Team> getTeam(String teamGid) throws IOException {
-                return getTeam(teamGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
+            CollectionRequest<Team> req = new CollectionRequest<Team>(this, Team.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-            /**
-            * Get teams in an organization
-            * Returns the compact records for all teams in the organization visible to the authorized user.
-                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Team>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Team> getTeamsForOrganization(String workspaceGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/organizations/{workspace_gid}/teams".replace("{workspace_gid}", workspaceGid);
+            return req;
+        }
 
-                CollectionRequest<Team> req = new CollectionRequest<Team>(this, Team.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
+        public CollectionRequest<Team> getTeamsForOrganization(String workspaceGid) throws IOException {
+            return getTeamsForOrganization(workspaceGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Get teams for a user
+        * Returns the compact records for all teams to which the given user is assigned.
+            * @param userGid Globally unique identifier for the user. (required)
+            * @param organization The workspace or organization to filter teams on. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Team>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Team> getTeamsForUser(String userGid, String organization, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/users/{user_gid}/teams".replace("{user_gid}", userGid);
 
-                return req;
-            }
+            CollectionRequest<Team> req = new CollectionRequest<Team>(this, Team.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset)
+                .query("organization", organization);
 
-            public CollectionRequest<Team> getTeamsForOrganization(String workspaceGid) throws IOException {
-                return getTeamsForOrganization(workspaceGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
+            return req;
+        }
 
-            /**
-            * Get teams for a user
-            * Returns the compact records for all teams to which the given user is assigned.
-                * @param userGid Globally unique identifier for the user. (required)
-                * @param organization The workspace or organization to filter teams on. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Team>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Team> getTeamsForUser(String userGid, String organization, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/users/{user_gid}/teams".replace("{user_gid}", userGid);
+        public CollectionRequest<Team> getTeamsForUser(String userGid, String organization) throws IOException {
+            return getTeamsForUser(userGid, organization, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Remove a user from a team
+        * The user making this call must be a member of the team in order to remove themselves or others.
+            * @param teamGid Globally unique identifier for the team. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> removeUserForTeam(String teamGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/teams/{team_gid}/removeUser".replace("{team_gid}", teamGid);
 
-                CollectionRequest<Team> req = new CollectionRequest<Team>(this, Team.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset)
-                    .query("organization", organization);
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                return req;
-            }
+            return req;
+        }
 
-            public CollectionRequest<Team> getTeamsForUser(String userGid, String organization) throws IOException {
-                return getTeamsForUser(userGid, organization, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
-            /**
-            * Remove a user from a team
-            * The user making this call must be a member of the team in order to remove themselves or others.
-                * @param teamGid Globally unique identifier for the team. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> removeUserForTeam(String teamGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/teams/{team_gid}/removeUser".replace("{team_gid}", teamGid);
-
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<JsonElement> removeUserForTeam(String teamGid) throws IOException {
-                return removeUserForTeam(teamGid, null, false);
-            }
-
+        public ItemRequest<JsonElement> removeUserForTeam(String teamGid) throws IOException {
+            return removeUserForTeam(teamGid, null, false);
+        }
     }

--- a/src/main/java/com/asana/resources/gen/TeamsBase.java
+++ b/src/main/java/com/asana/resources/gen/TeamsBase.java
@@ -95,7 +95,7 @@ import java.util.List;
         /**
         * Get teams for a user
         * Returns the compact records for all teams to which the given user is assigned.
-            * @param userGid Globally unique identifier for the user. (required)
+            * @param userGid A string identifying a user. This can either be the string \&quot;me\&quot;, an email, or the gid of a user. (required)
             * @param organization The workspace or organization to filter teams on. (required)
             * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
             * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)

--- a/src/main/java/com/asana/resources/gen/TypeaheadBase.java
+++ b/src/main/java/com/asana/resources/gen/TypeaheadBase.java
@@ -4,9 +4,12 @@ import com.asana.Client;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
+import com.asana.models.*;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
     public class TypeaheadBase extends Resource {
@@ -15,35 +18,34 @@ import java.util.List;
     */
     public TypeaheadBase(Client client) { super(client); }
 
-            /**
-            * Get objects via typeahead
-            * Retrieves objects in the workspace based via an auto-completion/typeahead search algorithm. This feature is meant to provide results quickly, so do not rely on this API to provide extremely accurate search results. The result set is limited to a single page of results with a maximum size, so you won’t be able to fetch large numbers of results.  The typeahead search API provides search for objects from a single workspace. This endpoint should be used to query for objects when creating an auto-completion/typeahead search feature. This API is meant to provide results quickly and should not be relied upon for accurate or exhaustive search results. The results sets are limited in size and cannot be paginated.  Queries return a compact representation of each object which is typically the gid and name fields. Interested in a specific set of fields or all of the fields?! Of course you are. Use field selectors to manipulate what data is included in a response.
-                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
-                * @param count The number of results to return. The default is 20 if this parameter is omitted, with a minimum of 1 and a maximum of 100. If there are fewer results found than requested, all will be returned. (optional)
-                * @param query The string that will be used to search for relevant objects. If an empty string is passed in, the API will currently return an empty result set. (optional)
-                * @param type *Deprecated: new integrations should prefer the resource_type field.* (optional)
-                * @param resourceType The type of values the typeahead should return. You can choose from one of the following: &#x60;custom_field&#x60;, &#x60;project&#x60;, &#x60;portfolio&#x60;, &#x60;tag&#x60;, &#x60;task&#x60;, and &#x60;user&#x60;. Note that unlike in the names of endpoints, the types listed here are in singular form (e.g. &#x60;task&#x60;). Using multiple types is not yet supported. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<JsonElement> typeaheadForWorkspace(String workspaceGid, Integer count, String query, String type, String resourceType, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/workspaces/{workspace_gid}/typeahead".replace("{workspace_gid}", workspaceGid);
+        /**
+        * Get objects via typeahead
+        * Retrieves objects in the workspace based via an auto-completion/typeahead search algorithm. This feature is meant to provide results quickly, so do not rely on this API to provide extremely accurate search results. The result set is limited to a single page of results with a maximum size, so you won’t be able to fetch large numbers of results.  The typeahead search API provides search for objects from a single workspace. This endpoint should be used to query for objects when creating an auto-completion/typeahead search feature. This API is meant to provide results quickly and should not be relied upon for accurate or exhaustive search results. The results sets are limited in size and cannot be paginated.  Queries return a compact representation of each object which is typically the gid and name fields. Interested in a specific set of fields or all of the fields?! Of course you are. Use field selectors to manipulate what data is included in a response.
+            * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+            * @param count The number of results to return. The default is 20 if this parameter is omitted, with a minimum of 1 and a maximum of 100. If there are fewer results found than requested, all will be returned. (optional)
+            * @param query The string that will be used to search for relevant objects. If an empty string is passed in, the API will currently return an empty result set. (optional)
+            * @param type *Deprecated: new integrations should prefer the resource_type field.* (optional)
+            * @param resourceType The type of values the typeahead should return. You can choose from one of the following: &#x60;custom_field&#x60;, &#x60;project&#x60;, &#x60;portfolio&#x60;, &#x60;tag&#x60;, &#x60;task&#x60;, and &#x60;user&#x60;. Note that unlike in the names of endpoints, the types listed here are in singular form (e.g. &#x60;task&#x60;). Using multiple types is not yet supported. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<JsonElement> typeaheadForWorkspace(String workspaceGid, Integer count, String query, String type, String resourceType, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/workspaces/{workspace_gid}/typeahead".replace("{workspace_gid}", workspaceGid);
 
-                CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "GET")
-                    .query("resource_type", resourceType)
-                    .query("type", type)
-                    .query("query", query)
-                    .query("count", count)
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "GET")
+                .query("resource_type", resourceType)
+                .query("type", type)
+                .query("query", query)
+                .query("count", count)
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                return req;
-            }
+            return req;
+        }
 
-            public CollectionRequest<JsonElement> typeaheadForWorkspace(String workspaceGid, Integer count, String query, String type, String resourceType) throws IOException {
-                return typeaheadForWorkspace(workspaceGid, count, query, type, resourceType, null, false);
-            }
-
+        public CollectionRequest<JsonElement> typeaheadForWorkspace(String workspaceGid, Integer count, String query, String type, String resourceType) throws IOException {
+            return typeaheadForWorkspace(workspaceGid, count, query, type, resourceType, null, false);
+        }
     }

--- a/src/main/java/com/asana/resources/gen/TypeaheadBase.java
+++ b/src/main/java/com/asana/resources/gen/TypeaheadBase.java
@@ -1,0 +1,49 @@
+package com.asana.resources.gen;
+
+import com.asana.Client;
+import com.asana.resources.Resource;
+import com.asana.requests.ItemRequest;
+import com.asana.requests.CollectionRequest;
+import com.google.gson.JsonElement;
+
+import java.io.IOException;
+import java.util.List;
+
+    public class TypeaheadBase extends Resource {
+    /**
+    * @param client Parent client instance
+    */
+    public TypeaheadBase(Client client) { super(client); }
+
+            /**
+            * Get objects via typeahead
+            * Retrieves objects in the workspace based via an auto-completion/typeahead search algorithm. This feature is meant to provide results quickly, so do not rely on this API to provide extremely accurate search results. The result set is limited to a single page of results with a maximum size, so you won’t be able to fetch large numbers of results.  The typeahead search API provides search for objects from a single workspace. This endpoint should be used to query for objects when creating an auto-completion/typeahead search feature. This API is meant to provide results quickly and should not be relied upon for accurate or exhaustive search results. The results sets are limited in size and cannot be paginated.  Queries return a compact representation of each object which is typically the gid and name fields. Interested in a specific set of fields or all of the fields?! Of course you are. Use field selectors to manipulate what data is included in a response.
+                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+                * @param count The number of results to return. The default is 20 if this parameter is omitted, with a minimum of 1 and a maximum of 100. If there are fewer results found than requested, all will be returned. (optional)
+                * @param query The string that will be used to search for relevant objects. If an empty string is passed in, the API will currently return an empty result set. (optional)
+                * @param type *Deprecated: new integrations should prefer the resource_type field.* (optional)
+                * @param resourceType The type of values the typeahead should return. You can choose from one of the following: &#x60;custom_field&#x60;, &#x60;project&#x60;, &#x60;portfolio&#x60;, &#x60;tag&#x60;, &#x60;task&#x60;, and &#x60;user&#x60;. Note that unlike in the names of endpoints, the types listed here are in singular form (e.g. &#x60;task&#x60;). Using multiple types is not yet supported. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<JsonElement> typeaheadForWorkspace(String workspaceGid, Integer count, String query, String type, String resourceType, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/workspaces/{workspace_gid}/typeahead".replace("{workspace_gid}", workspaceGid);
+
+                CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "GET")
+                    .query("resource_type", resourceType)
+                    .query("type", type)
+                    .query("query", query)
+                    .query("count", count)
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public CollectionRequest<JsonElement> typeaheadForWorkspace(String workspaceGid, Integer count, String query, String type, String resourceType) throws IOException {
+                return typeaheadForWorkspace(workspaceGid, count, query, type, resourceType, null, false);
+            }
+
+    }

--- a/src/main/java/com/asana/resources/gen/UserTaskListsBase.java
+++ b/src/main/java/com/asana/resources/gen/UserTaskListsBase.java
@@ -4,10 +4,12 @@ import com.asana.Client;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
-import com.asana.models.UserTaskList;
+import com.asana.models.*;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
     public class UserTaskListsBase extends Resource {
@@ -16,52 +18,50 @@ import java.util.List;
     */
     public UserTaskListsBase(Client client) { super(client); }
 
-            /**
-            * Get a user task list
-            * Returns the full record for a user task list.
-                * @param userTaskListGid Globally unique identifier for the user task list. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<UserTaskList>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<UserTaskList> getUserTaskList(String userTaskListGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/user_task_lists/{user_task_list_gid}".replace("{user_task_list_gid}", userTaskListGid);
+        /**
+        * Get a user task list
+        * Returns the full record for a user task list.
+            * @param userTaskListGid Globally unique identifier for the user task list. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<UserTaskList>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<UserTaskList> getUserTaskList(String userTaskListGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/user_task_lists/{user_task_list_gid}".replace("{user_task_list_gid}", userTaskListGid);
 
-                ItemRequest<UserTaskList> req = new ItemRequest<UserTaskList>(this, UserTaskList.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            ItemRequest<UserTaskList> req = new ItemRequest<UserTaskList>(this, UserTaskList.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                return req;
-            }
+            return req;
+        }
 
-            public ItemRequest<UserTaskList> getUserTaskList(String userTaskListGid) throws IOException {
-                return getUserTaskList(userTaskListGid, null, false);
-            }
+        public ItemRequest<UserTaskList> getUserTaskList(String userTaskListGid) throws IOException {
+            return getUserTaskList(userTaskListGid, null, false);
+        }
+        /**
+        * Get a user&#x27;s task list
+        * Returns the full record for a user&#x27;s task list.
+            * @param userGid Globally unique identifier for the user. (required)
+            * @param workspace The workspace in which to get the user task list. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<UserTaskList>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<UserTaskList> getUserTaskListForUser(String userGid, String workspace, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/users/{user_gid}/user_task_list".replace("{user_gid}", userGid);
 
-            /**
-            * Get a user&#x27;s task list
-            * Returns the full record for a user&#x27;s task list.
-                * @param userGid Globally unique identifier for the user. (required)
-                * @param workspace The workspace in which to get the user task list. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<UserTaskList>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<UserTaskList> getUserTaskListForUser(String userGid, String workspace, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/users/{user_gid}/user_task_list".replace("{user_gid}", userGid);
+            ItemRequest<UserTaskList> req = new ItemRequest<UserTaskList>(this, UserTaskList.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("workspace", workspace);
 
-                ItemRequest<UserTaskList> req = new ItemRequest<UserTaskList>(this, UserTaskList.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("workspace", workspace);
+            return req;
+        }
 
-                return req;
-            }
-
-            public ItemRequest<UserTaskList> getUserTaskListForUser(String userGid, String workspace) throws IOException {
-                return getUserTaskListForUser(userGid, workspace, null, false);
-            }
-
+        public ItemRequest<UserTaskList> getUserTaskListForUser(String userGid, String workspace) throws IOException {
+            return getUserTaskListForUser(userGid, workspace, null, false);
+        }
     }

--- a/src/main/java/com/asana/resources/gen/UserTaskListsBase.java
+++ b/src/main/java/com/asana/resources/gen/UserTaskListsBase.java
@@ -2,82 +2,66 @@ package com.asana.resources.gen;
 
 import com.asana.Client;
 import com.asana.resources.Resource;
-import com.asana.models.UserTaskList;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
+import com.asana.models.UserTaskList;
+import com.google.gson.JsonElement;
 
-/**
- * A _user task list_ represents the tasks assigned to a particular user. It provides API access to a user's "My Tasks" view in Asana.
- *
- * A user's "My Tasks" represent all of the tasks assigned to that user. It is
- * visually divided into regions based on the task's
- * [`assignee_status`](/developers/api-reference/tasks#field-assignee_status)
- * for Asana users to triage their tasks based on when they can address them.
- * When building an integration it's worth noting that tasks with due dates will
- * automatically move through `assignee_status` states as their due dates
- * approach; read up on [task
- * auto-promotion](/guide/help/fundamentals/my-tasks#gl-auto-promote) for more
- * infomation.
- */
-public class UserTaskListsBase extends Resource {
+import java.io.IOException;
+import java.util.List;
+
+    public class UserTaskListsBase extends Resource {
     /**
-     * @param client Parent client instance
-     */
-    public UserTaskListsBase(Client client) {
-        super(client);
+    * @param client Parent client instance
+    */
+    public UserTaskListsBase(Client client) { super(client); }
+
+            /**
+            * Get a user task list
+            * Returns the full record for a user task list.
+                * @param userTaskListGid Globally unique identifier for the user task list. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<UserTaskList>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<UserTaskList> getUserTaskList(String userTaskListGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/user_task_lists/{user_task_list_gid}".replace("{user_task_list_gid}", userTaskListGid);
+
+                ItemRequest<UserTaskList> req = new ItemRequest<UserTaskList>(this, UserTaskList.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<UserTaskList> getUserTaskList(String userTaskListGid) throws IOException {
+                return getUserTaskList(userTaskListGid, null, false);
+            }
+
+            /**
+            * Get a user&#x27;s task list
+            * Returns the full record for a user&#x27;s task list.
+                * @param userGid Globally unique identifier for the user. (required)
+                * @param workspace The workspace in which to get the user task list. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<UserTaskList>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<UserTaskList> getUserTaskListForUser(String userGid, String workspace, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/users/{user_gid}/user_task_list".replace("{user_gid}", userGid);
+
+                ItemRequest<UserTaskList> req = new ItemRequest<UserTaskList>(this, UserTaskList.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("workspace", workspace);
+
+                return req;
+            }
+
+            public ItemRequest<UserTaskList> getUserTaskListForUser(String userGid, String workspace) throws IOException {
+                return getUserTaskListForUser(userGid, workspace, null, false);
+            }
+
     }
-
-    /**
-     * Returns the full record for the user task list for the given user
-     *
-     * @param  user An identifier for the user. Can be one of an email address,
-     * the globally unique identifier for the user, or the keyword `me`
-     * to indicate the current user making the request.
-     * @return Request object
-     */
-    public ItemRequest<UserTaskList> findByUser(String user) {
-
-        String path = String.format("/users/%s/user_task_list", user);
-        return new ItemRequest<UserTaskList>(this, UserTaskList.class, path, "GET");
-    }
-
-    /**
-     * Returns the full record for a user task list.
-     *
-     * @param  userTaskList Globally unique identifier for the user task list.
-     * @return Request object
-     */
-    public ItemRequest<UserTaskList> findById(String userTaskList) {
-
-        String path = String.format("/user_task_lists/%s", userTaskList);
-        return new ItemRequest<UserTaskList>(this, UserTaskList.class, path, "GET");
-    }
-
-    /**
-     * Returns the compact list of tasks in a user's My Tasks list. The returned
-     * tasks will be in order within each assignee status group of `Inbox`,
-     * `Today`, and `Upcoming`.
-     *
-     * **Note:** tasks in `Later` have a different ordering in the Asana web app
-     * than the other assignee status groups; this endpoint will still return
-     * them in list order in `Later` (differently than they show up in Asana,
-     * but the same order as in Asana's mobile apps).
-     *
-     * **Note:** Access control is enforced for this endpoint as with all Asana
-     * API endpoints, meaning a user's private tasks will be filtered out if the
-     * API-authenticated user does not have access to them.
-     *
-     * **Note:** Both complete and incomplete tasks are returned by default
-     * unless they are filtered out (for example, setting `completed_since=now`
-     * will return only incomplete tasks, which is the default view for "My
-     * Tasks" in Asana.)
-     *
-     * @param  userTaskList The user task list in which to search for tasks.
-     * @return Request object
-     */
-    public CollectionRequest<UserTaskList> tasks(String userTaskList) {
-
-        String path = String.format("/user_task_lists/%s/tasks", userTaskList);
-        return new CollectionRequest<UserTaskList>(this, UserTaskList.class, path, "GET");
-    }
-}

--- a/src/main/java/com/asana/resources/gen/UserTaskListsBase.java
+++ b/src/main/java/com/asana/resources/gen/UserTaskListsBase.java
@@ -43,7 +43,7 @@ import java.util.List;
         /**
         * Get a user&#x27;s task list
         * Returns the full record for a user&#x27;s task list.
-            * @param userGid Globally unique identifier for the user. (required)
+            * @param userGid A string identifying a user. This can either be the string \&quot;me\&quot;, an email, or the gid of a user. (required)
             * @param workspace The workspace in which to get the user task list. (required)
             * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
             * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)

--- a/src/main/java/com/asana/resources/gen/UsersBase.java
+++ b/src/main/java/com/asana/resources/gen/UsersBase.java
@@ -1,89 +1,151 @@
 package com.asana.resources.gen;
 
 import com.asana.Client;
-import com.asana.models.ResourceWithSubtype;
 import com.asana.resources.Resource;
-import com.asana.models.User;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
+import com.asana.models.User;
+import com.google.gson.JsonElement;
 
-/**
- * A _user_ object represents an account in Asana that can be given access to
- * various workspaces, projects, and tasks.
- *
- * Like other objects in the system, users are referred to by numerical IDs.
- * However, the special string identifier `me` can be used anywhere
- * a user ID is accepted, to refer to the current authenticated user.
- */
-public class UsersBase extends Resource {
+import java.io.IOException;
+import java.util.List;
+
+    public class UsersBase extends Resource {
     /**
-     * @param client Parent client instance
-     */
-    public UsersBase(Client client) {
-        super(client);
+    * @param client Parent client instance
+    */
+    public UsersBase(Client client) { super(client); }
+
+            /**
+            * Get a user&#x27;s favorites
+            * Returns all of a user&#x27;s favorites in the given workspace, of the given type. Results are given in order (The same order as Asana&#x27;s sidebar).
+                * @param userGid Globally unique identifier for the user. (required)
+                * @param workspace The workspace in which to get favorites. (required)
+                * @param resourceType The resource type of favorites to be returned. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<JsonElement> getFavoritesForUser(String userGid, String workspace, String resourceType, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/users/{user_gid}/favorites".replace("{user_gid}", userGid);
+
+                CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("resource_type", resourceType)
+                    .query("workspace", workspace);
+
+                return req;
+            }
+
+            public CollectionRequest<JsonElement> getFavoritesForUser(String userGid, String workspace, String resourceType) throws IOException {
+                return getFavoritesForUser(userGid, workspace, resourceType, null, false);
+            }
+
+            /**
+            * Get a user
+            * Returns the full user record for the single user with the provided ID. Results are sorted by user ID.
+                * @param userGid Globally unique identifier for the user. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<User>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<User> getUser(String userGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/users/{user_gid}".replace("{user_gid}", userGid);
+
+                ItemRequest<User> req = new ItemRequest<User>(this, User.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<User> getUser(String userGid) throws IOException {
+                return getUser(userGid, null, false);
+            }
+
+            /**
+            * Get multiple users
+            * Returns the user records for all users in all workspaces and organizations accessible to the authenticated user. Accepts an optional workspace ID parameter. Results are sorted by user ID.
+                * @param workspace The workspace or organization ID to filter users on. (optional)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<User>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<User> getUsers(String workspace, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/users";
+
+                CollectionRequest<User> req = new CollectionRequest<User>(this, User.class, path, "GET")
+                    .query("workspace", workspace)
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public CollectionRequest<User> getUsers(String workspace) throws IOException {
+                return getUsers(workspace, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Get users in a team
+            * Returns the compact records for all users that are members of the team.
+                * @param teamGid Globally unique identifier for the team. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<User>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<User> getUsersForTeam(String teamGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/teams/{team_gid}/users".replace("{team_gid}", teamGid);
+
+                CollectionRequest<User> req = new CollectionRequest<User>(this, User.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public CollectionRequest<User> getUsersForTeam(String teamGid) throws IOException {
+                return getUsersForTeam(teamGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Get users in a workspace or organization
+            * Returns the user records for all users in the specified workspace or organization. Results are sorted alphabetically by user names.
+                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<User>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<User> getUsersForWorkspace(String workspaceGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/workspaces/{workspace_gid}/users".replace("{workspace_gid}", workspaceGid);
+
+                CollectionRequest<User> req = new CollectionRequest<User>(this, User.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public CollectionRequest<User> getUsersForWorkspace(String workspaceGid) throws IOException {
+                return getUsersForWorkspace(workspaceGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
     }
-
-    /**
-     * Returns the full user record for the currently authenticated user.
-     *
-     * @return Request object
-     */
-    public ItemRequest<User> me() {
-
-        return new ItemRequest<User>(this, User.class, "/users/me", "GET");
-    }
-
-    /**
-     * Returns the full user record for the single user with the provided ID.
-     *
-     * @param  user An identifier for the user. Can be one of an email address,
-     * the globally unique identifier for the user, or the keyword `me`
-     * to indicate the current user making the request.
-     * @return Request object
-     */
-    public ItemRequest<User> findById(String user) {
-
-        String path = String.format("/users/%s", user);
-        return new ItemRequest<User>(this, User.class, path, "GET");
-    }
-
-    /**
-     * Returns all of a user's favorites in the given workspace, of the given type.
-     * Results are given in order (The same order as Asana's sidebar).
-     *
-     * @param  user An identifier for the user. Can be one of an email address,
-     * the globally unique identifier for the user, or the keyword `me`
-     * to indicate the current user making the request.
-     * @return Request object
-     */
-    public CollectionRequest<ResourceWithSubtype> getUserFavorites(String user) {
-
-        String path = String.format("/users/%s/favorites", user);
-        return new CollectionRequest<ResourceWithSubtype>(this, ResourceWithSubtype.class, path, "GET");
-    }
-
-    /**
-     * Returns the user records for all users in the specified workspace or
-     * organization.
-     *
-     * @param  workspace The workspace in which to get users.
-     * @return Request object
-     */
-    public CollectionRequest<User> findByWorkspace(String workspace) {
-
-        String path = String.format("/workspaces/%s/users", workspace);
-        return new CollectionRequest<User>(this, User.class, path, "GET");
-    }
-
-    /**
-     * Returns the user records for all users in all workspaces and organizations
-     * accessible to the authenticated user. Accepts an optional workspace ID
-     * parameter.
-     *
-     * @return Request object
-     */
-    public CollectionRequest<User> findAll() {
-
-        return new CollectionRequest<User>(this, User.class, "/users", "GET");
-    }
-}

--- a/src/main/java/com/asana/resources/gen/UsersBase.java
+++ b/src/main/java/com/asana/resources/gen/UsersBase.java
@@ -4,10 +4,12 @@ import com.asana.Client;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
-import com.asana.models.User;
+import com.asana.models.*;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
     public class UsersBase extends Resource {
@@ -16,136 +18,131 @@ import java.util.List;
     */
     public UsersBase(Client client) { super(client); }
 
-            /**
-            * Get a user&#x27;s favorites
-            * Returns all of a user&#x27;s favorites in the given workspace, of the given type. Results are given in order (The same order as Asana&#x27;s sidebar).
-                * @param userGid Globally unique identifier for the user. (required)
-                * @param workspace The workspace in which to get favorites. (required)
-                * @param resourceType The resource type of favorites to be returned. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<JsonElement> getFavoritesForUser(String userGid, String workspace, String resourceType, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/users/{user_gid}/favorites".replace("{user_gid}", userGid);
+        /**
+        * Get a user&#x27;s favorites
+        * Returns all of a user&#x27;s favorites in the given workspace, of the given type. Results are given in order (The same order as Asana&#x27;s sidebar).
+            * @param userGid Globally unique identifier for the user. (required)
+            * @param workspace The workspace in which to get favorites. (required)
+            * @param resourceType The resource type of favorites to be returned. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<JsonElement> getFavoritesForUser(String userGid, String workspace, String resourceType, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/users/{user_gid}/favorites".replace("{user_gid}", userGid);
 
-                CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("resource_type", resourceType)
-                    .query("workspace", workspace);
+            CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("resource_type", resourceType)
+                .query("workspace", workspace);
 
-                return req;
-            }
+            return req;
+        }
 
-            public CollectionRequest<JsonElement> getFavoritesForUser(String userGid, String workspace, String resourceType) throws IOException {
-                return getFavoritesForUser(userGid, workspace, resourceType, null, false);
-            }
+        public CollectionRequest<JsonElement> getFavoritesForUser(String userGid, String workspace, String resourceType) throws IOException {
+            return getFavoritesForUser(userGid, workspace, resourceType, null, false);
+        }
+        /**
+        * Get a user
+        * Returns the full user record for the single user with the provided ID. Results are sorted by user ID.
+            * @param userGid Globally unique identifier for the user. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<User>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<User> getUser(String userGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/users/{user_gid}".replace("{user_gid}", userGid);
 
-            /**
-            * Get a user
-            * Returns the full user record for the single user with the provided ID. Results are sorted by user ID.
-                * @param userGid Globally unique identifier for the user. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<User>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<User> getUser(String userGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/users/{user_gid}".replace("{user_gid}", userGid);
+            ItemRequest<User> req = new ItemRequest<User>(this, User.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                ItemRequest<User> req = new ItemRequest<User>(this, User.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            return req;
+        }
 
-                return req;
-            }
+        public ItemRequest<User> getUser(String userGid) throws IOException {
+            return getUser(userGid, null, false);
+        }
+        /**
+        * Get multiple users
+        * Returns the user records for all users in all workspaces and organizations accessible to the authenticated user. Accepts an optional workspace ID parameter. Results are sorted by user ID.
+            * @param workspace The workspace or organization ID to filter users on. (optional)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<User>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<User> getUsers(String workspace, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/users";
 
-            public ItemRequest<User> getUser(String userGid) throws IOException {
-                return getUser(userGid, null, false);
-            }
+            CollectionRequest<User> req = new CollectionRequest<User>(this, User.class, path, "GET")
+                .query("workspace", workspace)
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-            /**
-            * Get multiple users
-            * Returns the user records for all users in all workspaces and organizations accessible to the authenticated user. Accepts an optional workspace ID parameter. Results are sorted by user ID.
-                * @param workspace The workspace or organization ID to filter users on. (optional)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<User>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<User> getUsers(String workspace, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/users";
+            return req;
+        }
 
-                CollectionRequest<User> req = new CollectionRequest<User>(this, User.class, path, "GET")
-                    .query("workspace", workspace)
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
+        public CollectionRequest<User> getUsers(String workspace) throws IOException {
+            return getUsers(workspace, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Get users in a team
+        * Returns the compact records for all users that are members of the team.
+            * @param teamGid Globally unique identifier for the team. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<User>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<User> getUsersForTeam(String teamGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/teams/{team_gid}/users".replace("{team_gid}", teamGid);
 
-                return req;
-            }
+            CollectionRequest<User> req = new CollectionRequest<User>(this, User.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-            public CollectionRequest<User> getUsers(String workspace) throws IOException {
-                return getUsers(workspace, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
+            return req;
+        }
 
-            /**
-            * Get users in a team
-            * Returns the compact records for all users that are members of the team.
-                * @param teamGid Globally unique identifier for the team. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<User>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<User> getUsersForTeam(String teamGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/teams/{team_gid}/users".replace("{team_gid}", teamGid);
+        public CollectionRequest<User> getUsersForTeam(String teamGid) throws IOException {
+            return getUsersForTeam(teamGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Get users in a workspace or organization
+        * Returns the user records for all users in the specified workspace or organization. Results are sorted alphabetically by user names.
+            * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<User>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<User> getUsersForWorkspace(String workspaceGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/workspaces/{workspace_gid}/users".replace("{workspace_gid}", workspaceGid);
 
-                CollectionRequest<User> req = new CollectionRequest<User>(this, User.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
+            CollectionRequest<User> req = new CollectionRequest<User>(this, User.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-                return req;
-            }
+            return req;
+        }
 
-            public CollectionRequest<User> getUsersForTeam(String teamGid) throws IOException {
-                return getUsersForTeam(teamGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
-            /**
-            * Get users in a workspace or organization
-            * Returns the user records for all users in the specified workspace or organization. Results are sorted alphabetically by user names.
-                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<User>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<User> getUsersForWorkspace(String workspaceGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/workspaces/{workspace_gid}/users".replace("{workspace_gid}", workspaceGid);
-
-                CollectionRequest<User> req = new CollectionRequest<User>(this, User.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
-
-                return req;
-            }
-
-            public CollectionRequest<User> getUsersForWorkspace(String workspaceGid) throws IOException {
-                return getUsersForWorkspace(workspaceGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
+        public CollectionRequest<User> getUsersForWorkspace(String workspaceGid) throws IOException {
+            return getUsersForWorkspace(workspaceGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
     }

--- a/src/main/java/com/asana/resources/gen/UsersBase.java
+++ b/src/main/java/com/asana/resources/gen/UsersBase.java
@@ -21,7 +21,7 @@ import java.util.List;
         /**
         * Get a user&#x27;s favorites
         * Returns all of a user&#x27;s favorites in the given workspace, of the given type. Results are given in order (The same order as Asana&#x27;s sidebar).
-            * @param userGid Globally unique identifier for the user. (required)
+            * @param userGid A string identifying a user. This can either be the string \&quot;me\&quot;, an email, or the gid of a user. (required)
             * @param workspace The workspace in which to get favorites. (required)
             * @param resourceType The resource type of favorites to be returned. (required)
             * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
@@ -47,7 +47,7 @@ import java.util.List;
         /**
         * Get a user
         * Returns the full user record for the single user with the provided ID. Results are sorted by user ID.
-            * @param userGid Globally unique identifier for the user. (required)
+            * @param userGid A string identifying a user. This can either be the string \&quot;me\&quot;, an email, or the gid of a user. (required)
             * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
             * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
         * @return ItemRequest<User>

--- a/src/main/java/com/asana/resources/gen/WebhooksBase.java
+++ b/src/main/java/com/asana/resources/gen/WebhooksBase.java
@@ -2,124 +2,116 @@ package com.asana.resources.gen;
 
 import com.asana.Client;
 import com.asana.resources.Resource;
-import com.asana.models.Webhook;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
+import com.asana.models.Webhook;
+import com.google.gson.JsonElement;
 
-/**
- * Webhooks allow an application to be notified of changes. This is in addition
- * to the ability to fetch those changes directly as
- * [Events](/developers/api-reference/events) - in fact, Webhooks are just a way
- * to receive Events via HTTP POST at the time they occur instead of polling for
- * them. For services accessible via HTTP this is often vastly more convenient,
- * and if events are not too frequent can be significantly more efficient.
- * 
- * In both cases, however, changes are represented as Event objects - refer to
- * the [Events documentation](/developers/api-reference/events) for more
- * information on what data these events contain.
- * 
- * **NOTE:** While Webhooks send arrays of Event objects to their target, the
- * Event objects themselves contain *only IDs*, rather than the actual resource
- * they are referencing. So while a normal event you receive via GET /events
- * would look like this:
- * 
- *     {\
- *       "resource": {\
- *         "id": 1337,\
- *         "resource_type": "task",\
- *         "name": "My Task"\
- *       },\
- *       "parent": null,\
- *       "created_at": "2013-08-21T18:20:37.972Z",\
- *       "user": {\
- *         "id": 1123,\
- *         "resource_type": "user",\
- *         "name": "Tom Bizarro"\
- *       },\
- *       "action": "changed",\
- *       "type": "task"\
- *     }
- * 
- * In a Webhook payload you would instead receive this:
- * 
- *     {\
- *       "resource": 1337,\
- *       "parent": null,\
- *       "created_at": "2013-08-21T18:20:37.972Z",\
- *       "user": 1123,\
- *       "action": "changed",\
- *       "type": "task"\
- *     }
- * 
- * Webhooks themselves contain only the information necessary to deliver the
- * events to the desired target as they are generated.
- */
-public class WebhooksBase extends Resource {
-    /**
-     * @param client Parent client instance
-     */
-    public WebhooksBase(Client client) {
-        super(client);
-    }
+import java.io.IOException;
+import java.util.List;
 
+    public class WebhooksBase extends Resource {
     /**
-     * Establishing a webhook is a two-part process. First, a simple HTTP POST
-     * similar to any other resource creation. Since you could have multiple
-     * webhooks we recommend specifying a unique local id for each target.
-     * 
-     * Next comes the confirmation handshake. When a webhook is created, we will
-     * send a test POST to the `target` with an `X-Hook-Secret` header as
-     * described in the
-     * [Resthooks Security documentation](http://resthooks.org/docs/security/).
-     * The target must respond with a `200 OK` and a matching `X-Hook-Secret`
-     * header to confirm that this webhook subscription is indeed expected.
-     * 
-     * If you do not acknowledge the webhook's confirmation handshake it will
-     * fail to setup, and you will receive an error in response to your attempt
-     * to create it. This means you need to be able to receive and complete the
-     * webhook *while* the POST request is in-flight.
-     *
-     * @return Request object
-     */
-    public ItemRequest<Webhook> create() {
-    
-        return new ItemRequest<Webhook>(this, Webhook.class, "/webhooks", "POST");
-    }
+    * @param client Parent client instance
+    */
+    public WebhooksBase(Client client) { super(client); }
 
-    /**
-     * Returns the compact representation of all webhooks your app has
-     * registered for the authenticated user in the given workspace.
-     *
-     * @return Request object
-     */
-    public CollectionRequest<Webhook> getAll() {
-    
-        return new CollectionRequest<Webhook>(this, Webhook.class, "/webhooks", "GET");
-    }
+            /**
+            * Establish a webhook
+            * Establishing a webhook is a two-part process. First, a simple HTTP POST similar to any other resource creation. Since you could have multiple webhooks we recommend specifying a unique local id for each target.  Next comes the confirmation handshake. When a webhook is created, we will send a test POST to the target with an &#x60;X-Hook-Secret&#x60; header as described in the [Resthooks Security documentation](http://resthooks.org/docs/security/). The target must respond with a &#x60;200 OK&#x60; and a matching &#x60;X-Hook-Secret&#x60; header to confirm that this webhook subscription is indeed expected.  If you do not acknowledge the webhook’s confirmation handshake it will fail to setup, and you will receive an error in response to your attempt to create it. This means you need to be able to receive and complete the webhook *while* the POST request is in-flight.  &#x60;&#x60;&#x60; # Request curl -H \&quot;Authorization: Bearer &lt;personal_access_token&gt;\&quot; \\ -X POST https://app.asana.com/api/1.0/webhooks \\ -d \&quot;resource&#x3D;8675309\&quot; \\ -d \&quot;target&#x3D;https://example.com/receive-webhook/7654\&quot; &#x60;&#x60;&#x60;  &#x60;&#x60;&#x60; # Handshake sent to https://example.com/ POST /receive-webhook/7654 X-Hook-Secret: b537207f20cbfa02357cf448134da559e8bd39d61597dcd5631b8012eae53e81 &#x60;&#x60;&#x60;  &#x60;&#x60;&#x60; # Handshake response sent by example.com HTTP/1.1 200 X-Hook-Secret: b537207f20cbfa02357cf448134da559e8bd39d61597dcd5631b8012eae53e81 &#x60;&#x60;&#x60;  &#x60;&#x60;&#x60; # Response HTTP/1.1 201 {   \&quot;data\&quot;: {     \&quot;gid\&quot;: \&quot;43214\&quot;,     \&quot;resource\&quot;: {       \&quot;gid\&quot;: \&quot;8675309\&quot;,       \&quot;name\&quot;: \&quot;Bugs\&quot;     },     \&quot;target\&quot;: \&quot;https://example.com/receive-webhook/7654\&quot;,     \&quot;active\&quot;: false,     \&quot;last_success_at\&quot;: null,     \&quot;last_failure_at\&quot;: null,     \&quot;last_failure_content\&quot;: null   } } &#x60;&#x60;&#x60;
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Webhook>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Webhook> createWebhook(List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/webhooks";
 
-    /**
-     * Returns the full record for the given webhook.
-     *
-     * @param  webhook The webhook to get.
-     * @return Request object
-     */
-    public ItemRequest<Webhook> getById(String webhook) {
-    
-        String path = String.format("/webhooks/%s", webhook);
-        return new ItemRequest<Webhook>(this, Webhook.class, path, "GET");
-    }
+                ItemRequest<Webhook> req = new ItemRequest<Webhook>(this, Webhook.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
 
-    /**
-     * This method permanently removes a webhook. Note that it may be possible
-     * to receive a request that was already in flight after deleting the
-     * webhook, but no further requests will be issued.
-     *
-     * @param  webhook The webhook to delete.
-     * @return Request object
-     */
-    public ItemRequest<Webhook> deleteById(String webhook) {
-    
-        String path = String.format("/webhooks/%s", webhook);
-        return new ItemRequest<Webhook>(this, Webhook.class, path, "DELETE");
+                return req;
+            }
+
+            public ItemRequest<Webhook> createWebhook() throws IOException {
+                return createWebhook(null, false);
+            }
+
+            /**
+            * Delete a webhook
+            * This method *permanently* removes a webhook. Note that it may be possible to receive a request that was already in flight after deleting the webhook, but no further requests will be issued.
+                * @param webhookGid Globally unique identifier for the webhook. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> deleteWebhook(String webhookGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/webhooks/{webhook_gid}".replace("{webhook_gid}", webhookGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> deleteWebhook(String webhookGid) throws IOException {
+                return deleteWebhook(webhookGid, null, false);
+            }
+
+            /**
+            * Get a webhook
+            * Returns the full record for the given webhook.
+                * @param webhookGid Globally unique identifier for the webhook. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Webhook>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Webhook> getWebhook(String webhookGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/webhooks/{webhook_gid}".replace("{webhook_gid}", webhookGid);
+
+                ItemRequest<Webhook> req = new ItemRequest<Webhook>(this, Webhook.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<Webhook> getWebhook(String webhookGid) throws IOException {
+                return getWebhook(webhookGid, null, false);
+            }
+
+            /**
+            * Get multiple webhooks
+            * Get the compact representation of all webhooks your app has registered for the authenticated user in the given workspace.
+                * @param resource Only return webhooks for the given resource. (optional)
+                * @param workspace The workspace to query for webhooks in. (required)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Webhook>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Webhook> getWebhooks(String resource, String workspace, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/webhooks";
+
+                CollectionRequest<Webhook> req = new CollectionRequest<Webhook>(this, Webhook.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset)
+                    .query("workspace", workspace)
+                    .query("resource", resource);
+
+                return req;
+            }
+
+            public CollectionRequest<Webhook> getWebhooks(String resource, String workspace) throws IOException {
+                return getWebhooks(resource, workspace, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
     }
-}

--- a/src/main/java/com/asana/resources/gen/WebhooksBase.java
+++ b/src/main/java/com/asana/resources/gen/WebhooksBase.java
@@ -4,10 +4,12 @@ import com.asana.Client;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
-import com.asana.models.Webhook;
+import com.asana.models.*;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
     public class WebhooksBase extends Resource {
@@ -16,102 +18,98 @@ import java.util.List;
     */
     public WebhooksBase(Client client) { super(client); }
 
-            /**
-            * Establish a webhook
-            * Establishing a webhook is a two-part process. First, a simple HTTP POST similar to any other resource creation. Since you could have multiple webhooks we recommend specifying a unique local id for each target.  Next comes the confirmation handshake. When a webhook is created, we will send a test POST to the target with an &#x60;X-Hook-Secret&#x60; header as described in the [Resthooks Security documentation](http://resthooks.org/docs/security/). The target must respond with a &#x60;200 OK&#x60; and a matching &#x60;X-Hook-Secret&#x60; header to confirm that this webhook subscription is indeed expected.  If you do not acknowledge the webhook’s confirmation handshake it will fail to setup, and you will receive an error in response to your attempt to create it. This means you need to be able to receive and complete the webhook *while* the POST request is in-flight.  &#x60;&#x60;&#x60; # Request curl -H \&quot;Authorization: Bearer &lt;personal_access_token&gt;\&quot; \\ -X POST https://app.asana.com/api/1.0/webhooks \\ -d \&quot;resource&#x3D;8675309\&quot; \\ -d \&quot;target&#x3D;https://example.com/receive-webhook/7654\&quot; &#x60;&#x60;&#x60;  &#x60;&#x60;&#x60; # Handshake sent to https://example.com/ POST /receive-webhook/7654 X-Hook-Secret: b537207f20cbfa02357cf448134da559e8bd39d61597dcd5631b8012eae53e81 &#x60;&#x60;&#x60;  &#x60;&#x60;&#x60; # Handshake response sent by example.com HTTP/1.1 200 X-Hook-Secret: b537207f20cbfa02357cf448134da559e8bd39d61597dcd5631b8012eae53e81 &#x60;&#x60;&#x60;  &#x60;&#x60;&#x60; # Response HTTP/1.1 201 {   \&quot;data\&quot;: {     \&quot;gid\&quot;: \&quot;43214\&quot;,     \&quot;resource\&quot;: {       \&quot;gid\&quot;: \&quot;8675309\&quot;,       \&quot;name\&quot;: \&quot;Bugs\&quot;     },     \&quot;target\&quot;: \&quot;https://example.com/receive-webhook/7654\&quot;,     \&quot;active\&quot;: false,     \&quot;last_success_at\&quot;: null,     \&quot;last_failure_at\&quot;: null,     \&quot;last_failure_content\&quot;: null   } } &#x60;&#x60;&#x60;
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Webhook>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Webhook> createWebhook(List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/webhooks";
+        /**
+        * Establish a webhook
+        * Establishing a webhook is a two-part process. First, a simple HTTP POST similar to any other resource creation. Since you could have multiple webhooks we recommend specifying a unique local id for each target.  Next comes the confirmation handshake. When a webhook is created, we will send a test POST to the target with an &#x60;X-Hook-Secret&#x60; header as described in the [Resthooks Security documentation](http://resthooks.org/docs/security/). The target must respond with a &#x60;200 OK&#x60; and a matching &#x60;X-Hook-Secret&#x60; header to confirm that this webhook subscription is indeed expected.  If you do not acknowledge the webhook’s confirmation handshake it will fail to setup, and you will receive an error in response to your attempt to create it. This means you need to be able to receive and complete the webhook *while* the POST request is in-flight.  &#x60;&#x60;&#x60; # Request curl -H \&quot;Authorization: Bearer &lt;personal_access_token&gt;\&quot; \\ -X POST https://app.asana.com/api/1.0/webhooks \\ -d \&quot;resource&#x3D;8675309\&quot; \\ -d \&quot;target&#x3D;https://example.com/receive-webhook/7654\&quot; &#x60;&#x60;&#x60;  &#x60;&#x60;&#x60; # Handshake sent to https://example.com/ POST /receive-webhook/7654 X-Hook-Secret: b537207f20cbfa02357cf448134da559e8bd39d61597dcd5631b8012eae53e81 &#x60;&#x60;&#x60;  &#x60;&#x60;&#x60; # Handshake response sent by example.com HTTP/1.1 200 X-Hook-Secret: b537207f20cbfa02357cf448134da559e8bd39d61597dcd5631b8012eae53e81 &#x60;&#x60;&#x60;  &#x60;&#x60;&#x60; # Response HTTP/1.1 201 {   \&quot;data\&quot;: {     \&quot;gid\&quot;: \&quot;43214\&quot;,     \&quot;resource\&quot;: {       \&quot;gid\&quot;: \&quot;8675309\&quot;,       \&quot;name\&quot;: \&quot;Bugs\&quot;     },     \&quot;target\&quot;: \&quot;https://example.com/receive-webhook/7654\&quot;,     \&quot;active\&quot;: false,     \&quot;last_success_at\&quot;: null,     \&quot;last_failure_at\&quot;: null,     \&quot;last_failure_content\&quot;: null   } } &#x60;&#x60;&#x60;
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Webhook>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Webhook> createWebhook(List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/webhooks";
 
-                ItemRequest<Webhook> req = new ItemRequest<Webhook>(this, Webhook.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            ItemRequest<Webhook> req = new ItemRequest<Webhook>(this, Webhook.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                return req;
-            }
+            return req;
+        }
 
-            public ItemRequest<Webhook> createWebhook() throws IOException {
-                return createWebhook(null, false);
-            }
+        public ItemRequest<Webhook> createWebhook() throws IOException {
+            return createWebhook(null, false);
+        }
+        /**
+        * Delete a webhook
+        * This method *permanently* removes a webhook. Note that it may be possible to receive a request that was already in flight after deleting the webhook, but no further requests will be issued.
+            * @param webhookGid Globally unique identifier for the webhook. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> deleteWebhook(String webhookGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/webhooks/{webhook_gid}".replace("{webhook_gid}", webhookGid);
 
-            /**
-            * Delete a webhook
-            * This method *permanently* removes a webhook. Note that it may be possible to receive a request that was already in flight after deleting the webhook, but no further requests will be issued.
-                * @param webhookGid Globally unique identifier for the webhook. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> deleteWebhook(String webhookGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/webhooks/{webhook_gid}".replace("{webhook_gid}", webhookGid);
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "DELETE")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            return req;
+        }
 
-                return req;
-            }
+        public ItemRequest<JsonElement> deleteWebhook(String webhookGid) throws IOException {
+            return deleteWebhook(webhookGid, null, false);
+        }
+        /**
+        * Get a webhook
+        * Returns the full record for the given webhook.
+            * @param webhookGid Globally unique identifier for the webhook. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Webhook>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Webhook> getWebhook(String webhookGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/webhooks/{webhook_gid}".replace("{webhook_gid}", webhookGid);
 
-            public ItemRequest<JsonElement> deleteWebhook(String webhookGid) throws IOException {
-                return deleteWebhook(webhookGid, null, false);
-            }
+            ItemRequest<Webhook> req = new ItemRequest<Webhook>(this, Webhook.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-            /**
-            * Get a webhook
-            * Returns the full record for the given webhook.
-                * @param webhookGid Globally unique identifier for the webhook. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Webhook>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Webhook> getWebhook(String webhookGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/webhooks/{webhook_gid}".replace("{webhook_gid}", webhookGid);
+            return req;
+        }
 
-                ItemRequest<Webhook> req = new ItemRequest<Webhook>(this, Webhook.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+        public ItemRequest<Webhook> getWebhook(String webhookGid) throws IOException {
+            return getWebhook(webhookGid, null, false);
+        }
+        /**
+        * Get multiple webhooks
+        * Get the compact representation of all webhooks your app has registered for the authenticated user in the given workspace.
+            * @param resource Only return webhooks for the given resource. (optional)
+            * @param workspace The workspace to query for webhooks in. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Webhook>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Webhook> getWebhooks(String resource, String workspace, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/webhooks";
 
-                return req;
-            }
+            CollectionRequest<Webhook> req = new CollectionRequest<Webhook>(this, Webhook.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset)
+                .query("workspace", workspace)
+                .query("resource", resource);
 
-            public ItemRequest<Webhook> getWebhook(String webhookGid) throws IOException {
-                return getWebhook(webhookGid, null, false);
-            }
+            return req;
+        }
 
-            /**
-            * Get multiple webhooks
-            * Get the compact representation of all webhooks your app has registered for the authenticated user in the given workspace.
-                * @param resource Only return webhooks for the given resource. (optional)
-                * @param workspace The workspace to query for webhooks in. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Webhook>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Webhook> getWebhooks(String resource, String workspace, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/webhooks";
-
-                CollectionRequest<Webhook> req = new CollectionRequest<Webhook>(this, Webhook.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset)
-                    .query("workspace", workspace)
-                    .query("resource", resource);
-
-                return req;
-            }
-
-            public CollectionRequest<Webhook> getWebhooks(String resource, String workspace) throws IOException {
-                return getWebhooks(resource, workspace, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
+        public CollectionRequest<Webhook> getWebhooks(String resource, String workspace) throws IOException {
+            return getWebhooks(resource, workspace, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
     }

--- a/src/main/java/com/asana/resources/gen/WorkspaceMembershipsBase.java
+++ b/src/main/java/com/asana/resources/gen/WorkspaceMembershipsBase.java
@@ -4,9 +4,12 @@ import com.asana.Client;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
+import com.asana.models.*;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
     public class WorkspaceMembershipsBase extends Resource {
@@ -15,83 +18,80 @@ import java.util.List;
     */
     public WorkspaceMembershipsBase(Client client) { super(client); }
 
-            /**
-            * Get a workspace membership
-            * Returns the complete workspace record for a single workspace membership.
-                * @param workspaceMembershipGid  (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> getWorkspaceMembership(String workspaceMembershipGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/workspace_memberships/{workspace_membership_gid}".replace("{workspace_membership_gid}", workspaceMembershipGid);
+        /**
+        * Get a workspace membership
+        * Returns the complete workspace record for a single workspace membership.
+            * @param workspaceMembershipGid  (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> getWorkspaceMembership(String workspaceMembershipGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/workspace_memberships/{workspace_membership_gid}".replace("{workspace_membership_gid}", workspaceMembershipGid);
 
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                return req;
-            }
+            return req;
+        }
 
-            public ItemRequest<JsonElement> getWorkspaceMembership(String workspaceMembershipGid) throws IOException {
-                return getWorkspaceMembership(workspaceMembershipGid, null, false);
-            }
+        public ItemRequest<JsonElement> getWorkspaceMembership(String workspaceMembershipGid) throws IOException {
+            return getWorkspaceMembership(workspaceMembershipGid, null, false);
+        }
+        /**
+        * Get workspace memberships for a user
+        * Returns the compact workspace membership records for the user.
+            * @param userGid Globally unique identifier for the user. (required)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<JsonElement> getWorkspaceMembershipsForUser(String userGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/users/{user_gid}/workspace_memberships".replace("{user_gid}", userGid);
 
-            /**
-            * Get workspace memberships for a user
-            * Returns the compact workspace membership records for the user.
-                * @param userGid Globally unique identifier for the user. (required)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<JsonElement> getWorkspaceMembershipsForUser(String userGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/users/{user_gid}/workspace_memberships".replace("{user_gid}", userGid);
+            CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-                CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
+            return req;
+        }
 
-                return req;
-            }
+        public CollectionRequest<JsonElement> getWorkspaceMembershipsForUser(String userGid) throws IOException {
+            return getWorkspaceMembershipsForUser(userGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Get the workspace memberships for a workspace
+        * Returns the compact workspace membership records for the workspace.
+            * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+            * @param user The user to filter results on. (optional)
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<JsonElement> getWorkspaceMembershipsForWorkspace(String workspaceGid, String user, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/workspaces/{workspace_gid}/workspace_memberships".replace("{workspace_gid}", workspaceGid);
 
-            public CollectionRequest<JsonElement> getWorkspaceMembershipsForUser(String userGid) throws IOException {
-                return getWorkspaceMembershipsForUser(userGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
+            CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "GET")
+                .query("user", user)
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-            /**
-            * Get the workspace memberships for a workspace
-            * Returns the compact workspace membership records for the workspace.
-                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
-                * @param user The user to filter results on. (optional)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<JsonElement> getWorkspaceMembershipsForWorkspace(String workspaceGid, String user, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/workspaces/{workspace_gid}/workspace_memberships".replace("{workspace_gid}", workspaceGid);
+            return req;
+        }
 
-                CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "GET")
-                    .query("user", user)
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
-
-                return req;
-            }
-
-            public CollectionRequest<JsonElement> getWorkspaceMembershipsForWorkspace(String workspaceGid, String user) throws IOException {
-                return getWorkspaceMembershipsForWorkspace(workspaceGid, user, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
+        public CollectionRequest<JsonElement> getWorkspaceMembershipsForWorkspace(String workspaceGid, String user) throws IOException {
+            return getWorkspaceMembershipsForWorkspace(workspaceGid, user, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
     }

--- a/src/main/java/com/asana/resources/gen/WorkspaceMembershipsBase.java
+++ b/src/main/java/com/asana/resources/gen/WorkspaceMembershipsBase.java
@@ -43,7 +43,7 @@ import java.util.List;
         /**
         * Get workspace memberships for a user
         * Returns the compact workspace membership records for the user.
-            * @param userGid Globally unique identifier for the user. (required)
+            * @param userGid A string identifying a user. This can either be the string \&quot;me\&quot;, an email, or the gid of a user. (required)
             * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
             * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
             * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
@@ -70,7 +70,7 @@ import java.util.List;
         * Get the workspace memberships for a workspace
         * Returns the compact workspace membership records for the workspace.
             * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
-            * @param user The user to filter results on. (optional)
+            * @param user A string identifying a user. This can either be the string \&quot;me\&quot;, an email, or the gid of a user. (optional)
             * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
             * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
             * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)

--- a/src/main/java/com/asana/resources/gen/WorkspaceMembershipsBase.java
+++ b/src/main/java/com/asana/resources/gen/WorkspaceMembershipsBase.java
@@ -4,60 +4,83 @@ import com.asana.Client;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
-import com.asana.models.PortfolioMembership;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
 import java.util.List;
 
-    public class PortfolioMembershipsBase extends Resource {
+    public class WorkspaceMembershipsBase extends Resource {
     /**
     * @param client Parent client instance
     */
-    public PortfolioMembershipsBase(Client client) { super(client); }
+    public WorkspaceMembershipsBase(Client client) { super(client); }
 
             /**
-            * Get a portfolio membership
-            * Returns the complete portfolio record for a single portfolio membership.
-                * @param portfolioMembershipGid  (required)
+            * Get a workspace membership
+            * Returns the complete workspace record for a single workspace membership.
+                * @param workspaceMembershipGid  (required)
                 * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
                 * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<PortfolioMembership>
+            * @return ItemRequest<JsonElement>
             * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
             */
-            public ItemRequest<PortfolioMembership> getPortfolioMembership(String portfolioMembershipGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/portfolio_memberships/{portfolio_membership_gid}".replace("{portfolio_membership_gid}", portfolioMembershipGid);
+            public ItemRequest<JsonElement> getWorkspaceMembership(String workspaceMembershipGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/workspace_memberships/{workspace_membership_gid}".replace("{workspace_membership_gid}", workspaceMembershipGid);
 
-                ItemRequest<PortfolioMembership> req = new ItemRequest<PortfolioMembership>(this, PortfolioMembership.class, path, "GET")
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "GET")
                     .query("opt_pretty", optPretty)
                     .query("opt_fields", optFields);
 
                 return req;
             }
 
-            public ItemRequest<PortfolioMembership> getPortfolioMembership(String portfolioMembershipGid) throws IOException {
-                return getPortfolioMembership(portfolioMembershipGid, null, false);
+            public ItemRequest<JsonElement> getWorkspaceMembership(String workspaceMembershipGid) throws IOException {
+                return getWorkspaceMembership(workspaceMembershipGid, null, false);
             }
 
             /**
-            * Get multiple portfolio memberships
-            * Returns a list of portfolio memberships in compact representation. You must specify &#x60;portfolio&#x60;, &#x60;portfolio&#x60; and &#x60;user&#x60;, or &#x60;workspace&#x60; and &#x60;user&#x60;.
-                * @param user The user to filter results on. (optional)
-                * @param workspace The workspace to filter results on. (optional)
-                * @param portfolio The portfolio to filter results on. (optional)
+            * Get workspace memberships for a user
+            * Returns the compact workspace membership records for the user.
+                * @param userGid Globally unique identifier for the user. (required)
                 * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
                 * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
                 * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
                 * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<PortfolioMembership>
+            * @return CollectionRequest<JsonElement>
             * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
             */
-            public CollectionRequest<PortfolioMembership> getPortfolioMemberships(String user, String workspace, String portfolio, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/portfolio_memberships";
+            public CollectionRequest<JsonElement> getWorkspaceMembershipsForUser(String userGid, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/users/{user_gid}/workspace_memberships".replace("{user_gid}", userGid);
 
-                CollectionRequest<PortfolioMembership> req = new CollectionRequest<PortfolioMembership>(this, PortfolioMembership.class, path, "GET")
-                    .query("portfolio", portfolio)
-                    .query("workspace", workspace)
+                CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public CollectionRequest<JsonElement> getWorkspaceMembershipsForUser(String userGid) throws IOException {
+                return getWorkspaceMembershipsForUser(userGid, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Get the workspace memberships for a workspace
+            * Returns the compact workspace membership records for the workspace.
+                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+                * @param user The user to filter results on. (optional)
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<JsonElement> getWorkspaceMembershipsForWorkspace(String workspaceGid, String user, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/workspaces/{workspace_gid}/workspace_memberships".replace("{workspace_gid}", workspaceGid);
+
+                CollectionRequest<JsonElement> req = new CollectionRequest<JsonElement>(this, JsonElement.class, path, "GET")
                     .query("user", user)
                     .query("opt_pretty", optPretty)
                     .query("opt_fields", optFields)
@@ -67,37 +90,8 @@ import java.util.List;
                 return req;
             }
 
-            public CollectionRequest<PortfolioMembership> getPortfolioMemberships(String user, String workspace, String portfolio) throws IOException {
-                return getPortfolioMemberships(user, workspace, portfolio, null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
-
-            /**
-            * Get memberships from a portfolio
-            * Returns the compact portfolio membership records for the portfolio.
-                * @param portfolioGid Globally unique identifier for the portfolio. (required)
-                * @param user The user to filter results on. (optional)
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<PortfolioMembership>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<PortfolioMembership> getPortfolioMembershipsForPortfolio(String portfolioGid, String user, String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/portfolios/{portfolio_gid}/portfolio_memberships".replace("{portfolio_gid}", portfolioGid);
-
-                CollectionRequest<PortfolioMembership> req = new CollectionRequest<PortfolioMembership>(this, PortfolioMembership.class, path, "GET")
-                    .query("user", user)
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
-
-                return req;
-            }
-
-            public CollectionRequest<PortfolioMembership> getPortfolioMembershipsForPortfolio(String portfolioGid, String user) throws IOException {
-                return getPortfolioMembershipsForPortfolio(portfolioGid, user, null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            public CollectionRequest<JsonElement> getWorkspaceMembershipsForWorkspace(String workspaceGid, String user) throws IOException {
+                return getWorkspaceMembershipsForWorkspace(workspaceGid, user, null, (int)Client.DEFAULTS.get("page_size"), null, false);
             }
 
     }

--- a/src/main/java/com/asana/resources/gen/WorkspacesBase.java
+++ b/src/main/java/com/asana/resources/gen/WorkspacesBase.java
@@ -1,115 +1,137 @@
 package com.asana.resources.gen;
 
 import com.asana.Client;
-import com.asana.models.ResourceWithSubtype;
 import com.asana.resources.Resource;
-import com.asana.models.Workspace;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
+import com.asana.models.Workspace;
+import com.google.gson.JsonElement;
 
-/**
- * A _workspace_ is the highest-level organizational unit in Asana. All projects
- * and tasks have an associated workspace.
- *
- * An _organization_ is a special kind of workspace that represents a company.
- * In an organization, you can group your projects into teams. You can read
- * more about how organizations work on the Asana Guide.
- * To tell if your workspace is an organization or not, check its
- * `is_organization` property.
- *
- * Over time, we intend to migrate most workspaces into organizations and to
- * release more organization-specific functionality. We may eventually deprecate
- * using workspace-based APIs for organizations. Currently, and until after
- * some reasonable grace period following any further announcements, you can
- * still reference organizations in any `workspace` parameter.
- */
-public class WorkspacesBase extends Resource {
+import java.io.IOException;
+import java.util.List;
+
+    public class WorkspacesBase extends Resource {
     /**
-     * @param client Parent client instance
-     */
-    public WorkspacesBase(Client client) {
-        super(client);
+    * @param client Parent client instance
+    */
+    public WorkspacesBase(Client client) { super(client); }
+
+            /**
+            * Add a user to a workspace or organization
+            * Add a user to a workspace or organization. The user can be referenced by their globally unique user ID or their email address. Returns the full user record for the invited user.
+                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<User>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<User> addUserForWorkspace(String workspaceGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/workspaces/{workspace_gid}/addUser".replace("{workspace_gid}", workspaceGid);
+
+                ItemRequest<User> req = new ItemRequest<User>(this, User.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<User> addUserForWorkspace(String workspaceGid) throws IOException {
+                return addUserForWorkspace(workspaceGid, null, false);
+            }
+
+            /**
+            * Get a workspace
+            * Returns the full workspace record for a single workspace.
+                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Workspace>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Workspace> getWorkspace(String workspaceGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/workspaces/{workspace_gid}".replace("{workspace_gid}", workspaceGid);
+
+                ItemRequest<Workspace> req = new ItemRequest<Workspace>(this, Workspace.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<Workspace> getWorkspace(String workspaceGid) throws IOException {
+                return getWorkspace(workspaceGid, null, false);
+            }
+
+            /**
+            * Get multiple workspaces
+            * Returns the compact records for all workspaces visible to the authorized user.
+                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return CollectionRequest<Workspace>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public CollectionRequest<Workspace> getWorkspaces(String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/workspaces";
+
+                CollectionRequest<Workspace> req = new CollectionRequest<Workspace>(this, Workspace.class, path, "GET")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields)
+                    .query("limit", limit)
+                    .query("offset", offset);
+
+                return req;
+            }
+
+            public CollectionRequest<Workspace> getWorkspaces() throws IOException {
+                return getWorkspaces(null, (int)Client.DEFAULTS.get("page_size"), null, false);
+            }
+
+            /**
+            * Remove a user from a workspace or organization
+            * Remove a user from a workspace or organization. The user making this call must be an admin in the workspace. The user can be referenced by their globally unique user ID or their email address. Returns an empty data record.
+                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<JsonElement>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<JsonElement> removeUserForWorkspace(String workspaceGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/workspaces/{workspace_gid}/removeUser".replace("{workspace_gid}", workspaceGid);
+
+                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<JsonElement> removeUserForWorkspace(String workspaceGid) throws IOException {
+                return removeUserForWorkspace(workspaceGid, null, false);
+            }
+
+            /**
+            * Update a workspace
+            * A specific, existing workspace can be updated by making a PUT request on the URL for that workspace. Only the fields provided in the data block will be updated; any unspecified fields will remain unchanged. Currently the only field that can be modified for a workspace is its name. Returns the complete, updated workspace record.
+                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+            * @return ItemRequest<Workspace>
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            */
+            public ItemRequest<Workspace> updateWorkspace(String workspaceGid, List<String> optFields, Boolean optPretty) throws IOException {
+                String path = "/workspaces/{workspace_gid}".replace("{workspace_gid}", workspaceGid);
+
+                ItemRequest<Workspace> req = new ItemRequest<Workspace>(this, Workspace.class, path, "PUT")
+                    .query("opt_pretty", optPretty)
+                    .query("opt_fields", optFields);
+
+                return req;
+            }
+
+            public ItemRequest<Workspace> updateWorkspace(String workspaceGid) throws IOException {
+                return updateWorkspace(workspaceGid, null, false);
+            }
+
     }
-
-    /**
-     * Returns the full workspace record for a single workspace.
-     *
-     * @param  workspace Globally unique identifier for the workspace or organization.
-     * @return Request object
-     */
-    public ItemRequest<Workspace> findById(String workspace) {
-
-        String path = String.format("/workspaces/%s", workspace);
-        return new ItemRequest<Workspace>(this, Workspace.class, path, "GET");
-    }
-
-    /**
-     * Returns the compact records for all workspaces visible to the authorized user.
-     *
-     * @return Request object
-     */
-    public CollectionRequest<Workspace> findAll() {
-
-        return new CollectionRequest<Workspace>(this, Workspace.class, "/workspaces", "GET");
-    }
-
-    /**
-     * A specific, existing workspace can be updated by making a PUT request on
-     * the URL for that workspace. Only the fields provided in the data block
-     * will be updated; any unspecified fields will remain unchanged.
-     *
-     * Currently the only field that can be modified for a workspace is its `name`.
-     *
-     * Returns the complete, updated workspace record.
-     *
-     * @param  workspace The workspace to update.
-     * @return Request object
-     */
-    public ItemRequest<Workspace> update(String workspace) {
-
-        String path = String.format("/workspaces/%s", workspace);
-        return new ItemRequest<Workspace>(this, Workspace.class, path, "PUT");
-    }
-
-    /**
-     * Retrieves objects in the workspace based on an auto-completion/typeahead
-     * search algorithm. This feature is meant to provide results quickly, so do
-     * not rely on this API to provide extremely accurate search results. The
-     * result set is limited to a single page of results with a maximum size,
-     * so you won't be able to fetch large numbers of results.
-     *
-     * @param  workspace The workspace to fetch objects from.
-     * @return Request object
-     */
-    public CollectionRequest<ResourceWithSubtype> typeahead(String workspace) {
-
-        String path = String.format("/workspaces/%s/typeahead", workspace);
-        return new CollectionRequest<ResourceWithSubtype>(this, ResourceWithSubtype.class, path, "GET");
-    }
-
-    /**
-     * The user can be referenced by their globally unique user ID or their email address.
-     * Returns the full user record for the invited user.
-     *
-     * @param  workspace The workspace or organization to invite the user to.
-     * @return Request object
-     */
-    public ItemRequest<Workspace> addUser(String workspace) {
-
-        String path = String.format("/workspaces/%s/addUser", workspace);
-        return new ItemRequest<Workspace>(this, Workspace.class, path, "POST");
-    }
-
-    /**
-     * The user making this call must be an admin in the workspace.
-     * Returns an empty data record.
-     *
-     * @param  workspace The workspace or organization to invite the user to.
-     * @return Request object
-     */
-    public ItemRequest<Workspace> removeUser(String workspace) {
-
-        String path = String.format("/workspaces/%s/removeUser", workspace);
-        return new ItemRequest<Workspace>(this, Workspace.class, path, "POST");
-    }
-}

--- a/src/main/java/com/asana/resources/gen/WorkspacesBase.java
+++ b/src/main/java/com/asana/resources/gen/WorkspacesBase.java
@@ -4,10 +4,12 @@ import com.asana.Client;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
-import com.asana.models.Workspace;
+import com.asana.models.*;
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
     public class WorkspacesBase extends Resource {
@@ -16,122 +18,117 @@ import java.util.List;
     */
     public WorkspacesBase(Client client) { super(client); }
 
-            /**
-            * Add a user to a workspace or organization
-            * Add a user to a workspace or organization. The user can be referenced by their globally unique user ID or their email address. Returns the full user record for the invited user.
-                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<User>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<User> addUserForWorkspace(String workspaceGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/workspaces/{workspace_gid}/addUser".replace("{workspace_gid}", workspaceGid);
+        /**
+        * Add a user to a workspace or organization
+        * Add a user to a workspace or organization. The user can be referenced by their globally unique user ID or their email address. Returns the full user record for the invited user.
+            * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<User>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<User> addUserForWorkspace(String workspaceGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/workspaces/{workspace_gid}/addUser".replace("{workspace_gid}", workspaceGid);
 
-                ItemRequest<User> req = new ItemRequest<User>(this, User.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            ItemRequest<User> req = new ItemRequest<User>(this, User.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                return req;
-            }
+            return req;
+        }
 
-            public ItemRequest<User> addUserForWorkspace(String workspaceGid) throws IOException {
-                return addUserForWorkspace(workspaceGid, null, false);
-            }
+        public ItemRequest<User> addUserForWorkspace(String workspaceGid) throws IOException {
+            return addUserForWorkspace(workspaceGid, null, false);
+        }
+        /**
+        * Get a workspace
+        * Returns the full workspace record for a single workspace.
+            * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Workspace>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Workspace> getWorkspace(String workspaceGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/workspaces/{workspace_gid}".replace("{workspace_gid}", workspaceGid);
 
-            /**
-            * Get a workspace
-            * Returns the full workspace record for a single workspace.
-                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Workspace>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Workspace> getWorkspace(String workspaceGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/workspaces/{workspace_gid}".replace("{workspace_gid}", workspaceGid);
+            ItemRequest<Workspace> req = new ItemRequest<Workspace>(this, Workspace.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                ItemRequest<Workspace> req = new ItemRequest<Workspace>(this, Workspace.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            return req;
+        }
 
-                return req;
-            }
+        public ItemRequest<Workspace> getWorkspace(String workspaceGid) throws IOException {
+            return getWorkspace(workspaceGid, null, false);
+        }
+        /**
+        * Get multiple workspaces
+        * Returns the compact records for all workspaces visible to the authorized user.
+            * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
+            * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return CollectionRequest<Workspace>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public CollectionRequest<Workspace> getWorkspaces(String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/workspaces";
 
-            public ItemRequest<Workspace> getWorkspace(String workspaceGid) throws IOException {
-                return getWorkspace(workspaceGid, null, false);
-            }
+            CollectionRequest<Workspace> req = new CollectionRequest<Workspace>(this, Workspace.class, path, "GET")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields)
+                .query("limit", limit)
+                .query("offset", offset);
 
-            /**
-            * Get multiple workspaces
-            * Returns the compact records for all workspaces visible to the authorized user.
-                * @param offset Offset token. An offset to the next page returned by the API. A pagination request will return an offset token, which can be used as an input parameter to the next request. If an offset is not passed in, the API will return the first page of results. &#x27;Note: You can only pass in an offset that was returned to you via a previously paginated request.&#x27; (optional)
-                * @param limit Results per page. The number of objects to return per page. The value must be between 1 and 100. (optional)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return CollectionRequest<Workspace>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public CollectionRequest<Workspace> getWorkspaces(String offset, Integer limit, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/workspaces";
+            return req;
+        }
 
-                CollectionRequest<Workspace> req = new CollectionRequest<Workspace>(this, Workspace.class, path, "GET")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields)
-                    .query("limit", limit)
-                    .query("offset", offset);
+        public CollectionRequest<Workspace> getWorkspaces() throws IOException {
+            return getWorkspaces(null, (int)Client.DEFAULTS.get("page_size"), null, false);
+        }
+        /**
+        * Remove a user from a workspace or organization
+        * Remove a user from a workspace or organization. The user making this call must be an admin in the workspace. The user can be referenced by their globally unique user ID or their email address. Returns an empty data record.
+            * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<JsonElement>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<JsonElement> removeUserForWorkspace(String workspaceGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/workspaces/{workspace_gid}/removeUser".replace("{workspace_gid}", workspaceGid);
 
-                return req;
-            }
+            ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-            public CollectionRequest<Workspace> getWorkspaces() throws IOException {
-                return getWorkspaces(null, (int)Client.DEFAULTS.get("page_size"), null, false);
-            }
+            return req;
+        }
 
-            /**
-            * Remove a user from a workspace or organization
-            * Remove a user from a workspace or organization. The user making this call must be an admin in the workspace. The user can be referenced by their globally unique user ID or their email address. Returns an empty data record.
-                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<JsonElement>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<JsonElement> removeUserForWorkspace(String workspaceGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/workspaces/{workspace_gid}/removeUser".replace("{workspace_gid}", workspaceGid);
+        public ItemRequest<JsonElement> removeUserForWorkspace(String workspaceGid) throws IOException {
+            return removeUserForWorkspace(workspaceGid, null, false);
+        }
+        /**
+        * Update a workspace
+        * A specific, existing workspace can be updated by making a PUT request on the URL for that workspace. Only the fields provided in the data block will be updated; any unspecified fields will remain unchanged. Currently the only field that can be modified for a workspace is its name. Returns the complete, updated workspace record.
+            * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
+            * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
+            * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
+        * @return ItemRequest<Workspace>
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        */
+        public ItemRequest<Workspace> updateWorkspace(String workspaceGid, List<String> optFields, Boolean optPretty) throws IOException {
+            String path = "/workspaces/{workspace_gid}".replace("{workspace_gid}", workspaceGid);
 
-                ItemRequest<JsonElement> req = new ItemRequest<JsonElement>(this, JsonElement.class, path, "POST")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
+            ItemRequest<Workspace> req = new ItemRequest<Workspace>(this, Workspace.class, path, "PUT")
+                .query("opt_pretty", optPretty)
+                .query("opt_fields", optFields);
 
-                return req;
-            }
+            return req;
+        }
 
-            public ItemRequest<JsonElement> removeUserForWorkspace(String workspaceGid) throws IOException {
-                return removeUserForWorkspace(workspaceGid, null, false);
-            }
-
-            /**
-            * Update a workspace
-            * A specific, existing workspace can be updated by making a PUT request on the URL for that workspace. Only the fields provided in the data block will be updated; any unspecified fields will remain unchanged. Currently the only field that can be modified for a workspace is its name. Returns the complete, updated workspace record.
-                * @param workspaceGid Globally unique identifier for the workspace or organization. (required)
-                * @param optFields Defines fields to return. Some requests return *compact* representations of objects in order to conserve resources and complete the request more efficiently. Other times requests return more information than you may need. This option allows you to list the exact set of fields that the API should be sure to return for the objects. The field names should be provided as paths, described below. The id of included objects will always be returned, regardless of the field options. (optional)
-                * @param optPretty Provides “pretty” output. Provides the response in a “pretty” format. In the case of JSON this means doing proper line breaking and indentation to make it readable. This will take extra time and increase the response size so it is advisable only to use this during debugging. (optional)
-            * @return ItemRequest<Workspace>
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            */
-            public ItemRequest<Workspace> updateWorkspace(String workspaceGid, List<String> optFields, Boolean optPretty) throws IOException {
-                String path = "/workspaces/{workspace_gid}".replace("{workspace_gid}", workspaceGid);
-
-                ItemRequest<Workspace> req = new ItemRequest<Workspace>(this, Workspace.class, path, "PUT")
-                    .query("opt_pretty", optPretty)
-                    .query("opt_fields", optFields);
-
-                return req;
-            }
-
-            public ItemRequest<Workspace> updateWorkspace(String workspaceGid) throws IOException {
-                return updateWorkspace(workspaceGid, null, false);
-            }
-
+        public ItemRequest<Workspace> updateWorkspace(String workspaceGid) throws IOException {
+            return updateWorkspace(workspaceGid, null, false);
+        }
     }

--- a/swagger_templates/api.mustache
+++ b/swagger_templates/api.mustache
@@ -4,15 +4,15 @@ import com.asana.Client;
 import com.asana.resources.Resource;
 import com.asana.requests.ItemRequest;
 import com.asana.requests.CollectionRequest;
-{{#firstClassResponseObject baseName}}
-import com.asana.models.{{firstClassResponseObject baseName}};
-{{/firstClassResponseObject}}
+import com.asana.models.*;
 {{#needsFileImport baseName}}
 import java.io.File;
 {{/needsFileImport}}
 import com.google.gson.JsonElement;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 {{#operations}}
@@ -24,30 +24,29 @@ import java.util.List;
 
     {{#operation}}
         {{#contents}}
-            /**
-            * {{summary}}
-            * {{notes}}{{#allParams}}
-                * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{/allParams}}
-            * @return {{#returnContainer}}{{returnContainer}}<{{/returnContainer}}{{#if (firstClassResponseObject returnType)}}{{firstClassResponseObject returnType}}{{else}}JsonElement{{/if}}{{#returnContainer}}>{{/returnContainer}}
-            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
-            {{#externalDocs}}
-                * {{description}}
-                * @see <a href="{{url}}">{{summary}} Documentation</a>
-            {{/externalDocs}}
-            */
-            public {{#returnContainer}}{{returnContainer}}<{{/returnContainer}}{{#if (firstClassResponseObject returnType)}}{{firstClassResponseObject returnType}}{{else}}JsonElement{{/if}}{{#returnContainer}}>{{/returnContainer}} {{operationId}}({{#allParams}}{{#if useBeanValidation}}{{>beanValidationQueryParams}}{{/if}}{{#unless @first}}, {{/unless}}{{{dataType}}} {{paramName}}{{/allParams}}) throws IOException {
-                String path = "{{path}}"{{#pathParams}}.replace("{ {{~baseName~}} }", {{paramName}}){{/pathParams}};
+        /**
+        * {{summary}}
+        * {{notes}}{{#allParams}}
+            * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{/allParams}}
+        * @return {{#returnContainer}}{{returnContainer}}<{{/returnContainer}}{{#if (firstClassResponseObject returnType)}}{{firstClassResponseObject returnType}}{{else}}JsonElement{{/if}}{{#returnContainer}}>{{/returnContainer}}
+        * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+        {{#externalDocs}}
+            * {{description}}
+            * @see <a href="{{url}}">{{summary}} Documentation</a>
+        {{/externalDocs}}
+        */
+        public {{#returnContainer}}{{returnContainer}}<{{/returnContainer}}{{#if (firstClassResponseObject returnType)}}{{firstClassResponseObject returnType}}{{else}}JsonElement{{/if}}{{#returnContainer}}>{{/returnContainer}} {{operationId}}({{#allParams}}{{#if useBeanValidation}}{{>beanValidationQueryParams}}{{/if}}{{#unless @first}}, {{/unless}}{{{dataType}}} {{paramName}}{{/allParams}}) throws IOException {
+            String path = "{{path}}"{{#pathParams}}.replace("{ {{~baseName~}} }", {{paramName}}){{/pathParams}};
 
-                {{#returnContainer}}{{returnContainer}}<{{/returnContainer}}{{#if (firstClassResponseObject returnType)}}{{firstClassResponseObject returnType}}{{else}}JsonElement{{/if}}{{#returnContainer}}>{{/returnContainer}} req = new {{#returnContainer}}{{returnContainer}}<{{/returnContainer}}{{#if (firstClassResponseObject returnType)}}{{firstClassResponseObject returnType}}{{else}}JsonElement{{/if}}{{#returnContainer}}>{{/returnContainer}}(this, {{#if (firstClassResponseObject returnType)}}{{firstClassResponseObject returnType}}{{else}}JsonElement{{/if}}.class, path, "{{httpMethod}}"){{#queryParams}}
-                    .query("{{baseName}}", {{paramName}}){{/queryParams}};
+            {{#returnContainer}}{{returnContainer}}<{{/returnContainer}}{{#if (firstClassResponseObject returnType)}}{{firstClassResponseObject returnType}}{{else}}JsonElement{{/if}}{{#returnContainer}}>{{/returnContainer}} req = new {{#returnContainer}}{{returnContainer}}<{{/returnContainer}}{{#if (firstClassResponseObject returnType)}}{{firstClassResponseObject returnType}}{{else}}JsonElement{{/if}}{{#returnContainer}}>{{/returnContainer}}(this, {{#if (firstClassResponseObject returnType)}}{{firstClassResponseObject returnType}}{{else}}JsonElement{{/if}}.class, path, "{{httpMethod}}"){{#queryParams}}
+                .query("{{baseName}}", {{paramName}}){{/queryParams}};
 
-                return req;
-            }
+            return req;
+        }
 
-            public {{#returnContainer}}{{returnContainer}}<{{/returnContainer}}{{#if (firstClassResponseObject returnType)}}{{firstClassResponseObject returnType}}{{else}}JsonElement{{/if}}{{#returnContainer}}>{{/returnContainer}} {{operationId}}({{#allParams}}{{#neq baseName 'offset'}}{{#neq baseName 'limit'}}{{#neq baseName 'opt_pretty'}}{{#neq baseName 'opt_fields'}}{{#unless @first}}, {{/unless}}{{#if useBeanValidation}}{{>beanValidationQueryParams}}{{/if}}{{{dataType}}} {{paramName}}{{/neq}}{{/neq}}{{/neq}}{{/neq}}{{/allParams}}) throws IOException {
-                return {{operationId}}({{#allParams}}{{#neq baseName 'offset'}}{{#neq baseName 'limit'}}{{#neq baseName 'opt_pretty'}}{{#neq baseName 'opt_fields'}}{{#unless @first}}, {{/unless}}{{#if useBeanValidation}}{{>beanValidationQueryParams}}{{/if}}{{paramName}}{{/neq}}{{/neq}}{{/neq}}{{/neq}}{{#eq baseName 'offset'}}{{#unless @first}}, {{/unless}}null{{/eq}}{{#eq baseName 'limit'}}{{#unless @first}}, {{/unless}}(int)Client.DEFAULTS.get("page_size"){{/eq}}{{#eq baseName 'opt_pretty'}}{{#unless @first}}, {{/unless}}false{{/eq}}{{#eq baseName 'opt_fields'}}{{#unless @first}}, {{/unless}}null{{/eq}}{{/allParams}});
-            }
-
+        public {{#returnContainer}}{{returnContainer}}<{{/returnContainer}}{{#if (firstClassResponseObject returnType)}}{{firstClassResponseObject returnType}}{{else}}JsonElement{{/if}}{{#returnContainer}}>{{/returnContainer}} {{operationId}}({{#allParams}}{{#neq baseName 'offset'}}{{#neq baseName 'limit'}}{{#neq baseName 'opt_pretty'}}{{#neq baseName 'opt_fields'}}{{#unless @first}}, {{/unless}}{{#if useBeanValidation}}{{>beanValidationQueryParams}}{{/if}}{{{dataType}}} {{paramName}}{{/neq}}{{/neq}}{{/neq}}{{/neq}}{{/allParams}}) throws IOException {
+            return {{operationId}}({{#allParams}}{{#neq baseName 'offset'}}{{#neq baseName 'limit'}}{{#neq baseName 'opt_pretty'}}{{#neq baseName 'opt_fields'}}{{#unless @first}}, {{/unless}}{{#if useBeanValidation}}{{>beanValidationQueryParams}}{{/if}}{{paramName}}{{/neq}}{{/neq}}{{/neq}}{{/neq}}{{#eq baseName 'offset'}}{{#unless @first}}, {{/unless}}null{{/eq}}{{#eq baseName 'limit'}}{{#unless @first}}, {{/unless}}(int)Client.DEFAULTS.get("page_size"){{/eq}}{{#eq baseName 'opt_pretty'}}{{#unless @first}}, {{/unless}}false{{/eq}}{{#eq baseName 'opt_fields'}}{{#unless @first}}, {{/unless}}null{{/eq}}{{/allParams}});
+        }
         {{/contents}}
     {{/operation}}
     }

--- a/swagger_templates/api.mustache
+++ b/swagger_templates/api.mustache
@@ -22,7 +22,7 @@ import java.util.List;
     */
     public {{baseName}}Base(Client client) { super(client); }
 
-    {{#operation}}
+    {{#operation}}{{^formParams}}
         {{#contents}}
         /**
         * {{summary}}
@@ -48,6 +48,6 @@ import java.util.List;
             return {{operationId}}({{#allParams}}{{#neq baseName 'offset'}}{{#neq baseName 'limit'}}{{#neq baseName 'opt_pretty'}}{{#neq baseName 'opt_fields'}}{{#unless @first}}, {{/unless}}{{#if useBeanValidation}}{{>beanValidationQueryParams}}{{/if}}{{paramName}}{{/neq}}{{/neq}}{{/neq}}{{/neq}}{{#eq baseName 'offset'}}{{#unless @first}}, {{/unless}}null{{/eq}}{{#eq baseName 'limit'}}{{#unless @first}}, {{/unless}}(int)Client.DEFAULTS.get("page_size"){{/eq}}{{#eq baseName 'opt_pretty'}}{{#unless @first}}, {{/unless}}false{{/eq}}{{#eq baseName 'opt_fields'}}{{#unless @first}}, {{/unless}}null{{/eq}}{{/allParams}});
         }
         {{/contents}}
-    {{/operation}}
+    {{/formParams}}{{/operation}}
     }
 {{/operations}}

--- a/swagger_templates/api.mustache
+++ b/swagger_templates/api.mustache
@@ -1,0 +1,54 @@
+package com.asana.resources.gen;
+
+import com.asana.Client;
+import com.asana.resources.Resource;
+import com.asana.requests.ItemRequest;
+import com.asana.requests.CollectionRequest;
+{{#firstClassResponseObject baseName}}
+import com.asana.models.{{firstClassResponseObject baseName}};
+{{/firstClassResponseObject}}
+{{#needsFileImport baseName}}
+import java.io.File;
+{{/needsFileImport}}
+import com.google.gson.JsonElement;
+
+import java.io.IOException;
+import java.util.List;
+
+{{#operations}}
+    public class {{baseName}}Base extends Resource {
+    /**
+    * @param client Parent client instance
+    */
+    public {{baseName}}Base(Client client) { super(client); }
+
+    {{#operation}}
+        {{#contents}}
+            /**
+            * {{summary}}
+            * {{notes}}{{#allParams}}
+                * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{/allParams}}
+            * @return {{#returnContainer}}{{returnContainer}}<{{/returnContainer}}{{#if (firstClassResponseObject returnType)}}{{firstClassResponseObject returnType}}{{else}}JsonElement{{/if}}{{#returnContainer}}>{{/returnContainer}}
+            * @throws IOException If we fail to call the API, e.g. server error or cannot deserialize the response body
+            {{#externalDocs}}
+                * {{description}}
+                * @see <a href="{{url}}">{{summary}} Documentation</a>
+            {{/externalDocs}}
+            */
+            public {{#returnContainer}}{{returnContainer}}<{{/returnContainer}}{{#if (firstClassResponseObject returnType)}}{{firstClassResponseObject returnType}}{{else}}JsonElement{{/if}}{{#returnContainer}}>{{/returnContainer}} {{operationId}}({{#allParams}}{{#if useBeanValidation}}{{>beanValidationQueryParams}}{{/if}}{{#unless @first}}, {{/unless}}{{{dataType}}} {{paramName}}{{/allParams}}) throws IOException {
+                String path = "{{path}}"{{#pathParams}}.replace("{ {{~baseName~}} }", {{paramName}}){{/pathParams}};
+
+                {{#returnContainer}}{{returnContainer}}<{{/returnContainer}}{{#if (firstClassResponseObject returnType)}}{{firstClassResponseObject returnType}}{{else}}JsonElement{{/if}}{{#returnContainer}}>{{/returnContainer}} req = new {{#returnContainer}}{{returnContainer}}<{{/returnContainer}}{{#if (firstClassResponseObject returnType)}}{{firstClassResponseObject returnType}}{{else}}JsonElement{{/if}}{{#returnContainer}}>{{/returnContainer}}(this, {{#if (firstClassResponseObject returnType)}}{{firstClassResponseObject returnType}}{{else}}JsonElement{{/if}}.class, path, "{{httpMethod}}"){{#queryParams}}
+                    .query("{{baseName}}", {{paramName}}){{/queryParams}};
+
+                return req;
+            }
+
+            public {{#returnContainer}}{{returnContainer}}<{{/returnContainer}}{{#if (firstClassResponseObject returnType)}}{{firstClassResponseObject returnType}}{{else}}JsonElement{{/if}}{{#returnContainer}}>{{/returnContainer}} {{operationId}}({{#allParams}}{{#neq baseName 'offset'}}{{#neq baseName 'limit'}}{{#neq baseName 'opt_pretty'}}{{#neq baseName 'opt_fields'}}{{#unless @first}}, {{/unless}}{{#if useBeanValidation}}{{>beanValidationQueryParams}}{{/if}}{{{dataType}}} {{paramName}}{{/neq}}{{/neq}}{{/neq}}{{/neq}}{{/allParams}}) throws IOException {
+                return {{operationId}}({{#allParams}}{{#neq baseName 'offset'}}{{#neq baseName 'limit'}}{{#neq baseName 'opt_pretty'}}{{#neq baseName 'opt_fields'}}{{#unless @first}}, {{/unless}}{{#if useBeanValidation}}{{>beanValidationQueryParams}}{{/if}}{{paramName}}{{/neq}}{{/neq}}{{/neq}}{{/neq}}{{#eq baseName 'offset'}}{{#unless @first}}, {{/unless}}null{{/eq}}{{#eq baseName 'limit'}}{{#unless @first}}, {{/unless}}(int)Client.DEFAULTS.get("page_size"){{/eq}}{{#eq baseName 'opt_pretty'}}{{#unless @first}}, {{/unless}}false{{/eq}}{{#eq baseName 'opt_fields'}}{{#unless @first}}, {{/unless}}null{{/eq}}{{/allParams}});
+            }
+
+        {{/contents}}
+    {{/operation}}
+    }
+{{/operations}}

--- a/swagger_templates/java-config.json
+++ b/swagger_templates/java-config.json
@@ -1,0 +1,9 @@
+{
+  "modelPackage" : "com.asana.models.gen",
+  "apiPackage"   : "com.asana.resources.gen",
+  "invokerPackage" : "com.asana",
+  "groupId" : "com.asana",
+  "dateLibrary" : "java8",
+  "hideGenerationTimestamp": true,
+  "generateApiTests": false
+}


### PR DESCRIPTION
This converts the client library generation to use swagger and our OpenAPI spec instead of asana-api-meta.

Function names are becoming more consistent and easier to guess. Upgrading to this version should not require any changes, however we did bump the java version from 7 to 8.

There are new functions and resources to be up-to-date with our API.

By switching to this generation, we're able to make our client more accurate, more robust, and more consistently up to date.

This new generator also offers to generate our models for us (They are currently manually maintained). We will be moving to that when possible to keep the models better up to date.