### PR TITLE
Update github actions publish to maven workflow to use gpg key

### DIFF
--- a/.github/workflows/publish-to-maven-central.yml
+++ b/.github/workflows/publish-to-maven-central.yml
@@ -18,8 +18,19 @@ jobs:
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
-      - name: Publish package
-        run: mvn --batch-mode deploy
+      - id: install-secret-key
+        name: Install gpg secret key
+        run: |
+         cat <(echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}") | gpg --batch --import
+         gpg --list-secret-keys --keyid-format LONG
+      - id: publish-to-central
+        name: Publish to Central Repository
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+        run: |
+          mvn \
+            --no-transfer-progress \
+            --batch-mode \
+            -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} \
+            clean deploy


### PR DESCRIPTION
- Update GitHub actions workflow for publishing to maven central to use gpg keys